### PR TITLE
Remove `sosa:Host` retain `sosa:Platform`

### DIFF
--- a/ssn/integrated/sosa.ttl
+++ b/ssn/integrated/sosa.ttl
@@ -199,6 +199,7 @@ sosa:Platform a rdfs:Class , owl:Class ;
   rdfs:comment "A Platform is an entity that hosts other entities, particularly Sensors, Actuators, Samplers, and other Platforms."@en ;
   skos:scopeNote "The UML class 'Host' from ISO 19156:2023 is implemented in SOSA by the OWL/RDFS class 'Platform'" ;
   skos:scopeNote "The INSPIRE 'Environmental Monitoring Facility' may be implemented using SOSA by the OWL/RDFS class 'Platform'" ;
+  dcterms:source <https://inspire.ec.europa.eu/id/document/tg/ef> ;
   skos:example """A post, buoy, vehicle, ship, aircraft, satellite, cell-phone, human or animal may act as platforms for (technical or biological) sensors or actuators.
   An environmental monitoring facility. 
   A platform that hosts a set of sensors. 

--- a/ssn/integrated/sosa.ttl
+++ b/ssn/integrated/sosa.ttl
@@ -197,7 +197,7 @@ sosa:Platform a rdfs:Class , owl:Class ;
   skos:altLabel "Host" ;
   skos:definition "A Platform is an entity that hosts other entities, particularly Sensors, Actuators, Samplers, and other Platforms."@en ;
   rdfs:comment "A Platform is an entity that hosts other entities, particularly Sensors, Actuators, Samplers, and other Platforms."@en ;
-  skos:editorialNote "The UML class 'Host' from ISO 19156:2023 is implemented in SOSA by the OWL/RDFS class 'Platform'"
+  skos:editorialNote "The UML class 'Host' from ISO 19156:2023 is implemented in SOSA by the OWL/RDFS class 'Platform'" ;
   skos:example """A post, buoy, vehicle, ship, aircraft, satellite, cell-phone, human or animal may act as platforms for (technical or biological) sensors or actuators.
   An environmental monitoring facility. 
   A platform that hosts a set of sensors. 

--- a/ssn/integrated/sosa.ttl
+++ b/ssn/integrated/sosa.ttl
@@ -192,22 +192,27 @@ sosa:hasMemberSample a owl:ObjectProperty ;
 ## Platform 
 
 sosa:Platform a rdfs:Class , owl:Class ;
-  rdfs:subClassOf sosa:Host ;
   rdfs:label "Platform"@en ;
+  skos:prefLabel "platform" ;
+  skos:altLabel "Host" ;
   skos:definition "A Platform is an entity that hosts other entities, particularly Sensors, Actuators, Samplers, and other Platforms."@en ;
   rdfs:comment "A Platform is an entity that hosts other entities, particularly Sensors, Actuators, Samplers, and other Platforms."@en ;
-  skos:example "A post, buoy, vehicle, ship, aircraft, satellite, cell-phone, human or animal may act as platforms for (technical or biological) sensors or actuators."@en ;
+  skos:editorialNote "The UML class 'Host' from ISO 19156:2023 is implemented in SOSA by the OWL/RDFS class 'Platform'"
+  skos:example """A post, buoy, vehicle, ship, aircraft, satellite, cell-phone, human or animal may act as platforms for (technical or biological) sensors or actuators.
+  An environmental monitoring facility. 
+  A platform that hosts a set of sensors. 
+  A team performing a survey, where each team member would be modeled as an Observer."""@en ;
   rdfs:isDefinedBy sosa: .
 
 sosa:hosts a owl:ObjectProperty ;
   rdfs:label "hosts"@en ;
   skos:definition "Relation between a Platform and a Sensor, Actuator, Sampler, or Platform, hosted or mounted on it."@en ;
   rdfs:comment "Relation between a Platform and a Sensor, Actuator, Sampler, or Platform, hosted or mounted on it."@en ;
-  schema:domainIncludes sosa:Host ;
+  schema:domainIncludes sosa:Platform ;
   schema:rangeIncludes sosa:Observer ;
   schema:rangeIncludes sosa:Actuator ;
   schema:rangeIncludes sosa:Sampler ;
-  schema:rangeIncludes sosa:Host ;
+  schema:rangeIncludes sosa:Platform ;
   owl:inverseOf sosa:isHostedBy ;
   rdfs:isDefinedBy sosa: .
 
@@ -218,16 +223,9 @@ sosa:isHostedBy a owl:ObjectProperty ;
   schema:domainIncludes sosa:Observer ;
   schema:domainIncludes sosa:Actuator ;
   schema:domainIncludes sosa:Sampler ;
-  schema:domainIncludes sosa:Host ;
-  schema:rangeIncludes sosa:Host ;
+  schema:domainIncludes sosa:Platform ;
+  schema:rangeIncludes sosa:Platform ;
   owl:inverseOf sosa:hosts ;
-  rdfs:isDefinedBy sosa: .
-
-sosa:Host a rdfs:Class , owl:Class ;
-  rdfs:label "Host"@en ;
-  skos:definition "A grouping of Observers for a specific reason."@en ;
-  rdfs:comment "A grouping of Observers for a specific reason."@en ;
-  skos:example "An environmental monitoring facility. A platform that hosts a set of sensors. A team performing a survey, where each team member would be modeled as an Observer."@en ;
   rdfs:isDefinedBy sosa: .
 
 
@@ -297,7 +295,6 @@ sosa:PreparationProcedure a rdfs:Class , owl:Class ;
 ## ProcedureExecutors
 
 sosa:Sensor a rdfs:Class , owl:Class ;
-  rdfs:subClassOf sosa:Observer ;
   rdfs:label "Sensor"@en ;
   skos:definition "Device, agent (including humans), or software (simulation) involved in, or implementing, a Procedure. Sensors respond to a stimulus, e.g., a change in the environment, or input data composed from the results of prior Observations, and generate a Result. Sensors can be hosted by Platforms."@en ;
   rdfs:comment "Device, agent (including humans), or software (simulation) involved in, or implementing, a Procedure. Sensors respond to a stimulus, e.g., a change in the environment, or input data composed from the results of prior Observations, and generate a Result. Sensors can be hosted by Platforms."@en ;
@@ -342,10 +339,10 @@ sosa:Observer a rdfs:Class , owl:Class ;
   rdfs:label "Observer"@en ;
   skos:definition "An identifiable entity that can generate Observations pertaining to an ObservableProperty by implementing an ObservingProcedure."@en ;
   rdfs:comment "An identifiable entity that can generate Observations pertaining to an ObservableProperty by implementing an ObservingProcedure."@en ;
-  skos:example "Accelerometers, gyroscopes, barometers, magnetometers, and so forth are Observers that are typically mounted on a modern smartphone (which acts as Host). Other examples of Sensors include the human eyes."@en ;
+  skos:example "Accelerometers, gyroscopes, barometers, magnetometers, and so forth are Observers that are typically mounted on a modern smartphone (which acts as Platform). Other examples of Sensors include the human eyes."@en ;
   skos:note "Different Observers can follow the same (reusable) observing Procedure for the creation of different Observations."@en ;
   skos:note "The Observer is the entity instance, not the entity type. Pertaining to sensors, the Observer would reference the explicit sensor, while the Procedure would reference the methodology utilized by that sensor type;"@en ;
-  skos:note "An Observer can be hosted by one or more Host."@en ;
+  skos:note "An Observer can be hosted by one or more Platform."@en ;
   skos:note "The Observer is an instance of a sensor, instrument, implementation of an algorithm, or a being such as a person."@en ;
   rdfs:isDefinedBy sosa: .
 
@@ -464,12 +461,12 @@ sosa:Observation a rdfs:Class , owl:Class ;
     owl:inverseOf sosa:madeObservation ;
     rdfs:isDefinedBy sosa: .
 
-  sosa:madeOnHost rdf:type owl:ObjectProperty ;
-    rdfs:label "made on host"@en ;
-    skos:definition "Relation between an Observation and the Host the Observer was attached to at the time the observation was made."@en ;
-    rdfs:comment "Relation between an Observation and the Host the Observer was attached to at the time the observation was made."@en ;
+  sosa:madeOnPlatform rdf:type owl:ObjectProperty ;
+    rdfs:label "made on Platform"@en ;
+    skos:definition "Relation between an Observation and the Platform the Observer was attached to at the time the observation was made."@en ;
+    rdfs:comment "Relation between an Observation and the Platform the Observer was attached to at the time the observation was made."@en ;
     schema:domainIncludes sosa:Observation ;
-    schema:rangeIncludes sosa:Host ;
+    schema:rangeIncludes sosa:Platform ;
     rdfs:isDefinedBy sosa: .
 
 sosa:Actuation a rdfs:Class , owl:Class ;
@@ -576,7 +573,7 @@ sosa:Observation
   - hasUltimateFeatureOfInterest
   - madeBySensor
   - madeByObserver
-  - madeOnHost
+  - madeOnPlatform
   - observedProperty
   - phenomenonTime
   - resultTime
@@ -607,7 +604,7 @@ sosa:madeBySensor
 sosa:madeByObserver
   schema:domainIncludes sosa:ObservationCollection .
 
-sosa:madeOnHost
+sosa:madeOnPlatform
   schema:domainIncludes sosa:ObservationCollection .
 
 sosa:observedProperty
@@ -764,8 +761,8 @@ sosa:System a owl:Class ;
 
 sosa:Deployment a owl:Class ;
   rdfs:label "Deployment"@en ;
-  skos:definition "Describes the Deployment of one or more assets for a particular purpose. Deployment may be done on a Host."@en ;
-  rdfs:comment "Describes the Deployment of one or more assets for a particular purpose. Deployment may be done on a Host."@en ;
+  skos:definition "Describes the Deployment of one or more assets for a particular purpose. Deployment may be done on a Platform."@en ;
+  rdfs:comment "Describes the Deployment of one or more assets for a particular purpose. Deployment may be done on a Platform."@en ;
   skos:example "For example, a temperature Sensor deployed on a wall, or a whole network of Sensors deployed for an Observation campaign."@en ;
   rdfs:isDefinedBy sosa: .
 
@@ -776,12 +773,13 @@ sosa:Deployment a owl:Class ;
     schema:domainIncludes sosa:Deployment ;
     rdfs:isDefinedBy sosa: .
 
-  sosa:deployedOnHost a owl:ObjectProperty ;
-    rdfs:label "deployed on host"@en ;
-    skos:definition "Relation between a Deployment and the Host on which the Systems are deployed."@en ;
-    rdfs:comment "Relation between a Deployment and the Host on which the Systems are deployed."@en ;
+  sosa:deployedOnPlatform a owl:ObjectProperty ;
+    rdfs:label "deployed on platform"@en ;
+    skos:definition "Relation between a Deployment and the Platform on which the Systems are deployed."@en ;
+    rdfs:comment "Relation between a Deployment and the Platform on which the Systems are deployed."@en ;
+    owl:inverseOf sosa:inDeployment ;
     schema:domainIncludes sosa:Deployment ;
-    schema:rangeIncludes sosa:Host ;
+    schema:rangeIncludes sosa:Platform ;
     rdfs:isDefinedBy sosa: .
 
   sosa:deployedSystem a owl:ObjectProperty ;
@@ -800,15 +798,6 @@ sosa:Deployment a owl:Class ;
     owl:inverseOf sosa:deployedSystem ;
     schema:domainIncludes sosa:System ;
     schema:rangeIncludes sosa:Deployment ;
-    rdfs:isDefinedBy sosa: .
-
-  sosa:deployedOnPlatform a owl:ObjectProperty ;
-    rdfs:label "deployed on platform"@en ;
-    skos:definition "Relation between a Deployment and the Platform on which the Systems are deployed."@en ;
-    rdfs:comment "Relation between a Deployment and the Platform on which the Systems are deployed."@en ;
-    owl:inverseOf sosa:inDeployment ;
-    schema:domainIncludes sosa:Deployment ;
-    schema:rangeIncludes sosa:Platform ;
     rdfs:isDefinedBy sosa: .
 
   sosa:inDeployment a owl:ObjectProperty ;

--- a/ssn/integrated/sosa.ttl
+++ b/ssn/integrated/sosa.ttl
@@ -197,7 +197,8 @@ sosa:Platform a rdfs:Class , owl:Class ;
   skos:altLabel "Host" ;
   skos:definition "A Platform is an entity that hosts other entities, particularly Sensors, Actuators, Samplers, and other Platforms."@en ;
   rdfs:comment "A Platform is an entity that hosts other entities, particularly Sensors, Actuators, Samplers, and other Platforms."@en ;
-  skos:editorialNote "The UML class 'Host' from ISO 19156:2023 is implemented in SOSA by the OWL/RDFS class 'Platform'" ;
+  skos:scopeNote "The UML class 'Host' from ISO 19156:2023 is implemented in SOSA by the OWL/RDFS class 'Platform'" ;
+  skos:scopeNote "The INSPIRE 'Environmental Monitoring Facility' may be implemented using SOSA by the OWL/RDFS class 'Platform'" ;
   skos:example """A post, buoy, vehicle, ship, aircraft, satellite, cell-phone, human or animal may act as platforms for (technical or biological) sensors or actuators.
   An environmental monitoring facility. 
   A platform that hosts a set of sensors. 

--- a/ssn/integrated/ssn.ttl
+++ b/ssn/integrated/ssn.ttl
@@ -515,7 +515,7 @@ sosa:Stimulus
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:isProxyFor ; owl:allValuesFrom sosa:ObservableProperty ] ;
   rdfs:isDefinedBy sosa: .
 
-  sosa:wasOriginatedBy owl:FunctionalProperty ;
+  sosa:wasOriginatedBy a owl:FunctionalProperty ;
     owl:equivalentProperty ssn:wasOriginatedBy ;
     rdfs:isDefinedBy sosa: .
 

--- a/ssn/integrated/ssn.ttl
+++ b/ssn/integrated/ssn.ttl
@@ -162,12 +162,7 @@ sosa:hasMemberSample a owl:ObjectProperty ;
 
 ## Platform
 
-sosa:Host
-  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:inDeployment ; owl:allValuesFrom ssn:Deployment ]  ;
-  rdfs:isDefinedBy sosa: .
-
 sosa:Platform 
-  rdfs:subClassOf sosa:Host ;
   rdfs:subClassOf ssn:System ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hosts ; owl:allValuesFrom ssn:System ]  ;
   rdfs:isDefinedBy sosa: .
@@ -288,7 +283,7 @@ sosa:Observer
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:implements ; owl:allValuesFrom sosa:ObservingProcedure ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:observes ; owl:allValuesFrom sosa:ObservableProperty ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeObservation ; owl:allValuesFrom sosa:Observation ] ;
-  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:isHostedBy ; owl:allValuesFrom sosa:Host ]  ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:isHostedBy ; owl:allValuesFrom sosa:Platform ]  ;
   rdfs:isDefinedBy sosa: .
 
 sosa:Sensor
@@ -353,8 +348,8 @@ sosa:Observation a owl:Class ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeByObserver ; owl:allValuesFrom sosa:Observer ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeBySensor ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeBySensor ; owl:allValuesFrom sosa:Sensor ] ;
-  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeOnHost ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
-  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeOnHost ; owl:allValuesFrom sosa:Host ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeOnPlatform ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeOnPlatform ; owl:allValuesFrom sosa:Platform ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:usedProcedure ; owl:allValuesFrom sosa:ObservingProcedure ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasFeatureOfInterest ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasFeatureOfInterest ; owl:allValuesFrom sosa:FeatureOfInterest ] ;
@@ -380,15 +375,12 @@ sosa:Observation a owl:Class ;
   sosa:madeByObserver 
     rdfs:isDefinedBy sosa: .
     
-  sosa:madeOnHost
+  sosa:madeOnPlatform
     rdfs:isDefinedBy sosa: .
     
   sosa:madeByObserver 
     rdfs:isDefinedBy sosa: .
     
-  sosa:madeOnHost
-    rdfs:isDefinedBy sosa: .
-
   sosa:observedProperty 
     rdfs:isDefinedBy sosa: .
 
@@ -461,8 +453,8 @@ sosa:ObservationCollection a owl:Class ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeByObserver ; owl:allValuesFrom sosa:Observer ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeBySensor ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeBySensor ; owl:allValuesFrom sosa:Sensor ] ;
-  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeOnHost ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
-  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeOnHost ; owl:allValuesFrom sosa:Host ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeOnPlatform ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeOnPlatform ; owl:allValuesFrom sosa:Platform ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:usedProcedure ; owl:allValuesFrom sosa:ObservingProcedure ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasFeatureOfInterest ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasFeatureOfInterest ; owl:allValuesFrom sosa:FeatureOfInterest ] ;
@@ -609,13 +601,12 @@ sosa:System
 ssn:Deployment a owl:Class ;
   owl:equivalentClass sosa:Deployment ;
   rdfs:label "Deployment"@en ;
-  skos:definition "Describes the Deployment of one or more assets for a particular purpose. Deployment may be done on a Host."@en ;
-  rdfs:comment "Describes the Deployment of one or more assets for a particular purpose. Deployment may be done on a Host."@en ;
+  skos:definition "Describes the Deployment of one or more assets for a particular purpose. Deployment may be done on a Platform."@en ;
+  rdfs:comment "Describes the Deployment of one or more assets for a particular purpose. Deployment may be done on a Platform."@en ;
   skos:example "For example, a temperature Sensor deployed on a wall, or a whole network of Sensors deployed for an Observation campaign."@en ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:deployedSystem ; owl:allValuesFrom ssn:System ] ;
-  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:deployedAsset ; owl:allValuesFrom [ a owl:Class ; owl:unionOf ( sosa:Observer sosa:Host ssn:System ) ] ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:deployedAsset ; owl:allValuesFrom [ a owl:Class ; owl:unionOf ( sosa:Observer sosa:Platform ssn:System ) ] ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:deployedOnPlatform ; owl:allValuesFrom sosa:Platform ]  ;
-  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:deployedOnHost ; owl:allValuesFrom sosa:Host ]  ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:forProperty ; owl:allValuesFrom ssn:Property ]  ;
   rdfs:isDefinedBy ssn: .
 
@@ -626,11 +617,12 @@ ssn:Deployment a owl:Class ;
     rdfs:comment "Relation between a Deployment and a deployed asset."@en ;
     rdfs:isDefinedBy ssn: .
 
-  ssn:deployedOnHost a owl:ObjectProperty ;
-    owl:equivalentProperty sosa:deployedOnHost ;
-    rdfs:label "deployed on host"@en ;
-    skos:definition "Relation between a Deployment and the Host on which the Systems are deployed."@en ;
-    rdfs:comment "Relation between a Deployment and the Host on which the Systems are deployed."@en ;
+  ssn:deployedOnPlatform a owl:ObjectProperty ;
+    owl:equivalentProperty sosa:deployedOnPlatform ;
+    rdfs:label "deployed on platform"@en ;
+    skos:definition "Relation between a Deployment and the Platform on which the Systems are deployed."@en ;
+    rdfs:comment "Relation between a Deployment and the Platform on which the Systems are deployed."@en ;
+    owl:inverseOf ssn:inDeployment ;
     rdfs:isDefinedBy ssn: .
 
   ssn:deployedSystem a owl:ObjectProperty ;
@@ -650,15 +642,6 @@ ssn:Deployment a owl:Class ;
     owl:inverseOf ssn:deployedSystem ;
     rdfs:isDefinedBy ssn: .
 
-  ssn:deployedOnPlatform a owl:ObjectProperty ;
-    owl:equivalentProperty sosa:deployedOnPlatform ;
-    rdfs:subPropertyOf ssn:deployedOnHost ;
-    rdfs:label "deployed on platform"@en ;
-    skos:definition "Relation between a Deployment and the Platform on which the Systems are deployed."@en ;
-    rdfs:comment "Relation between a Deployment and the Platform on which the Systems are deployed."@en ;
-    owl:inverseOf ssn:inDeployment ;
-    rdfs:isDefinedBy ssn: .
-
   ssn:inDeployment a owl:ObjectProperty ;
     owl:equivalentProperty sosa:inDeployment ;
     rdfs:label "in deployment"@en ;
@@ -674,9 +657,8 @@ ssn:Deployment a owl:Class ;
 sosa:Deployment 
   owl:equivalentClass ssn:Deployment ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:deployedSystem ; owl:allValuesFrom sosa:System ] ;
-  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:deployedAsset ; owl:allValuesFrom [ a owl:Class ; owl:unionOf ( sosa:Observer sosa:Host sosa:System ) ] ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:deployedAsset ; owl:allValuesFrom [ a owl:Class ; owl:unionOf ( sosa:Observer sosa:Platform sosa:System ) ] ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:deployedOnPlatform ; owl:allValuesFrom sosa:Platform ]  ;
-  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:deployedOnHost ; owl:allValuesFrom sosa:Host ]  ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:forProperty ; owl:allValuesFrom sosa:Property ]  ;
   rdfs:isDefinedBy sosa: .
 
@@ -684,8 +666,8 @@ sosa:Deployment
     owl:equivalentProperty ssn:deployedAsset ;
     rdfs:isDefinedBy sosa: .
 
-  sosa:deployedOnHost 
-    owl:equivalentProperty ssn:deployedOnHost ;
+  sosa:deployedOnPlatform 
+    owl:equivalentProperty ssn:deployedOnPlatform ;
     rdfs:isDefinedBy sosa: .
 
   sosa:deployedSystem 
@@ -694,10 +676,6 @@ sosa:Deployment
 
   sosa:hasDeployment 
     owl:equivalentProperty ssn:hasDeployment ;
-    rdfs:isDefinedBy sosa: .
-
-  sosa:deployedOnPlatform 
-    owl:equivalentProperty ssn:deployedOnPlatform ;
     rdfs:isDefinedBy sosa: .
 
   sosa:inDeployment 


### PR DESCRIPTION
Added note to explain that `sosa:Platform` is the SOSA implementation of OMS Host.

Closes #56 