### PR TITLE
missing predicate ('a' = rdf:type)

### DIFF
--- a/ssn/integrated/ssn.ttl
+++ b/ssn/integrated/ssn.ttl
@@ -523,7 +523,7 @@ sosa:Stimulus
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:isProxyFor ; owl:allValuesFrom sosa:ObservableProperty ] ;
   rdfs:isDefinedBy sosa: .
 
-  sosa:wasOriginatedBy owl:FunctionalProperty ;
+  sosa:wasOriginatedBy a owl:FunctionalProperty ;
     owl:equivalentProperty ssn:wasOriginatedBy ;
     rdfs:isDefinedBy sosa: .
 


### PR DESCRIPTION
Syntax error