### PR TITLE
Modifies SSN-Common abbreviation to ssn-common

### DIFF
--- a/ssn/integrated/ssn-actuation.ttl
+++ b/ssn/integrated/ssn-actuation.ttl
@@ -11,7 +11,7 @@
 @prefix sosa-common: <http://www.w3.org/ns/sosa/common/> .
 @prefix sosa-act: <http://www.w3.org/ns/sosa/act/> .
 @prefix ssn: <http://www.w3.org/ns/ssn/> .
-@prefix ssn-base: <http://www.w3.org/ns/ssn/common/> .
+@prefix ssn-common: <http://www.w3.org/ns/ssn/common/> .
 @prefix ssn-act: <http://www.w3.org/ns/ssn/act/> .
 
 
@@ -28,7 +28,7 @@ ssn-act:
   dcterms:license <http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document> ;
   dcterms:license <http://www.opengeospatial.org/ogc/Software> ;
   dcterms:created "2024-02-02"^^xsd:date ;
-  owl:imports sosa-act: , ssn-base: ;
+  owl:imports sosa-act: , ssn-common: ;
   .
 
 sosa:ActuatableProperty 

--- a/ssn/integrated/ssn-observation.ttl
+++ b/ssn/integrated/ssn-observation.ttl
@@ -13,7 +13,7 @@
 @prefix sosa-common: <http://www.w3.org/ns/sosa/common/> .
 @prefix sosa-obs: <http://www.w3.org/ns/sosa/obs/> .
 @prefix ssn: <http://www.w3.org/ns/ssn/> .
-@prefix ssn-base: <http://www.w3.org/ns/ssn/common/> .
+@prefix ssn-common: <http://www.w3.org/ns/ssn/common/> .
 @prefix ssn-obs: <http://www.w3.org/ns/ssn/obs/> .
 
 
@@ -26,7 +26,7 @@ ssn-obs:
   dcterms:license <http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document> ;
   dcterms:license <http://www.opengeospatial.org/ogc/Software> ;
   dcterms:created "2024-02-02"^^xsd:date ;
-  owl:imports sosa-obs: , ssn-base: ;
+  owl:imports sosa-obs: , ssn-common: ;
   .
 
 sosa:ObservableProperty 

--- a/ssn/integrated/ssn-sampling.ttl
+++ b/ssn/integrated/ssn-sampling.ttl
@@ -13,7 +13,7 @@
 @prefix sosa-common: <http://www.w3.org/ns/sosa/common/> .
 @prefix sosa-sam: <http://www.w3.org/ns/sosa/sam/> .
 @prefix ssn: <http://www.w3.org/ns/ssn/> .
-@prefix ssn-base: <http://www.w3.org/ns/ssn/common/> .
+@prefix ssn-common: <http://www.w3.org/ns/ssn/common/> .
 @prefix ssn-sam: <http://www.w3.org/ns/ssn/sam/> .
 
 
@@ -26,7 +26,7 @@ ssn-sam:
   dcterms:license <http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document> ;
   dcterms:license <http://www.opengeospatial.org/ogc/Software> ;
   dcterms:created "2024-02-02"^^xsd:date ;
-  owl:imports sosa-sam: , ssn-base: ;
+  owl:imports sosa-sam: , ssn-common: ;
   .
 
 sosa:Sample 


### PR DESCRIPTION
Modifies abbreviations of SSN-Common to `ssn_common:`, as with `sosa_common:`. 

Complements #192 and follows on https://github.com/w3c/sdw-sosa-ssn/commit/d2373b4f7e7870a784d2b528a7ef8212f4e975b5. 