### PR TITLE
Replaces 'graph' for 'module' in text literals

### DIFF
--- a/ssn/integrated/ssn-deprecated.ttl
+++ b/ssn/integrated/ssn-deprecated.ttl
@@ -27,7 +27,7 @@ ssn-dep: a owl:Ontology ;
   New modular version of the SSN ontology. 
   """@en ;
   rdfs:comment "Please report any errors to the W3C Spatial Data on the Web Working Group via the SDW WG Public List public-sdw-wg@w3.org"@en ;
-  skos:scopeNote "The SSN-DEP graph contains deprecated terms in the ssn: namespace. " ;
+  skos:scopeNote "The SSN-DEP module contains deprecated terms in the ssn: namespace. " ;
   skos:historyNote """
   Terms in the ssn: namespace have equivalence axioms to terms declared in the sosa: namespace, and are marked 'deprecated'. 
   The axiomatization from the 2017 version of the standard is preserved. 

--- a/ssn/integrated/ssn-oms.ttl
+++ b/ssn/integrated/ssn-oms.ttl
@@ -49,7 +49,7 @@ ssn-oms: a owl:Ontology ;
   dcterms:license <http://www.opengeospatial.org/ogc/Software> ;
   dcterms:created "2023-12-06"^^xsd:date ;
   dcterms:source <https://docs.ogc.org/as/20-082r4/20-082r4.html> ;
-  rdfs:comment "Vertical module adding SSN-style axioms to SOSA-OMS graph" ;
+  rdfs:comment "Vertical module adding SSN-style axioms to the SOSA-OMS module" ;
   owl:imports ssn-obs: , ssn-sam: , sosa-oms: ;
   .
 

--- a/ssn/integrated/ssn.ttl
+++ b/ssn/integrated/ssn.ttl
@@ -44,7 +44,7 @@ This ontology was originally developed in 2009-2011 by the W3C Semantic Sensor N
 
 In particular, (a) the scope is extended to include actuation and sampling; (b) the core concepts and properties are factored out into the SOSA ontology. The SSN ontology imports SOSA and adds formal axiomatization consistent with the text definitions in SOSA, and adds classes and properties to accommodate the scope of the original SSN ontology. """@en ;
   rdfs:comment "Please report any errors to the W3C Spatial Data on the Web Working Group via the SDW WG Public List public-sdw-wg@w3.org"@en ;
-  skos:scopeNote "The SSN graph contains an axiomatization of the core terms from the SOSA graph (serialized in the sosa:ttl file) plus some deprecated terms in the ssn: namespace. " ;
+  skos:scopeNote "The SSN module contains an axiomatization of the core terms from the SOSA module (serialized in the sosa:ttl file) plus some deprecated terms in the ssn: namespace. " ;
   skos:historyNote """
   Terms in the ssn: namespace have equivalence axioms to terms declared in the sosa: namespace, and are marked 'deprecated'. 
   The axiomatization from the 2017 version of the standard is preserved. 


### PR DESCRIPTION
Complements https://github.com/w3c/sdw-sosa-ssn/pull/186, particularly https://github.com/w3c/sdw-sosa-ssn/pull/186/commits/7092d22d2f2e1f5f1fad9bba28ac6ed9e2ae65b3. Follows up on discussion in the [meeting of the 1st of February](https://docs.google.com/document/d/15TBmYhgRjncdd_bvmTKygCD8aIhQo1-Tkg3eOKjYNTw/edit#heading=h.uzw5dp1j5k61).