### PR TITLE
Remove metadata element declarations

### DIFF
--- a/ssn/rdf/ontology/alignments/sosa-oandm.ttl
+++ b/ssn/rdf/ontology/alignments/sosa-oandm.ttl
@@ -21,14 +21,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/>.
 
-dcterms:creator a owl:AnnotationProperty .
-dcterms:created a owl:AnnotationProperty .
-dcterms:modified a owl:AnnotationProperty .
-dcterms:rights a owl:AnnotationProperty .
-dcterms:license a owl:AnnotationProperty .
-foaf:Agent a owl:Class .
-foaf:name a owl:AnnotationProperty .
-
 
 sosa:om
   rdf:type owl:Ontology ;

--- a/ssn/rdf/ontology/core/ssn.ttl
+++ b/ssn/rdf/ontology/core/ssn.ttl
@@ -17,18 +17,6 @@
 @prefix ssn-sam: <http://www.w3.org/ns/ssn/sam/> .
 
 
-dcterms:title a owl:AnnotationProperty .
-dcterms:description a owl:AnnotationProperty .
-dcterms:rights a owl:AnnotationProperty .
-dcterms:license a owl:AnnotationProperty .
-dcterms:created a owl:AnnotationProperty .
-dcterms:creator a owl:AnnotationProperty .
-foaf:Agent a owl:Class .
-foaf:name a owl:AnnotationProperty .
-skos:definition a owl:AnnotationProperty .
-skos:example a owl:AnnotationProperty .
-
-
 ssn: a owl:Ontology ;
   dcterms:title "Semantic Sensor Network Ontology"@en ;
   dcterms:description "This ontology describes sensors, actuators and observations, and related concepts. It does not describe domain concepts, time, locations, etc. these are intended to be included from other ontologies via OWL imports."@en ;

--- a/ssn/rdf/ontology/extensions/sosa-oms.ttl
+++ b/ssn/rdf/ontology/extensions/sosa-oms.ttl
@@ -19,22 +19,6 @@
 @prefix sosa-sam: <http://www.w3.org/ns/sosa/sam/> .
 @prefix sosa-oms: <http://www.w3.org/ns/sosa/oms/> .
 
-dcterms:title a owl:AnnotationProperty .
-dcterms:description a owl:AnnotationProperty .
-dcterms:rights a owl:AnnotationProperty .
-dcterms:license a owl:AnnotationProperty .
-dcterms:created a owl:AnnotationProperty .
-dcterms:creator a owl:AnnotationProperty .
-foaf:Agent a owl:Class .
-foaf:name a owl:AnnotationProperty .
-schema:domainIncludes a owl:AnnotationProperty .
-schema:rangeIncludes a owl:AnnotationProperty .
-skos:definition a owl:AnnotationProperty .
-skos:example a owl:AnnotationProperty .
-skos:note a owl:AnnotationProperty .
-time:TemporalEntity a owl:Class .
-
-
 sosa-oms: 
   a owl:Ontology ;
   dcterms:title "OMS Ontology - based on (SOSA) Ontology"@en ;

--- a/ssn/rdf/ontology/extensions/ssn-oms.ttl
+++ b/ssn/rdf/ontology/extensions/ssn-oms.ttl
@@ -22,22 +22,6 @@
 @prefix ssn-sam: <http://www.w3.org/ns/ssn/sam/> .
 @prefix ssn-oms: <http://www.w3.org/ns/ssn/oms/> .
 
-dcterms:title a owl:AnnotationProperty .
-dcterms:description a owl:AnnotationProperty .
-dcterms:rights a owl:AnnotationProperty .
-dcterms:license a owl:AnnotationProperty .
-dcterms:created a owl:AnnotationProperty .
-dcterms:creator a owl:AnnotationProperty .
-foaf:Agent a owl:Class .
-foaf:name a owl:AnnotationProperty .
-ogc-ms:implements a owl:ObjectProperty .
-schema:domainIncludes a owl:AnnotationProperty .
-schema:rangeIncludes a owl:AnnotationProperty .
-skos:definition a owl:AnnotationProperty .
-skos:example a owl:AnnotationProperty .
-skos:note a owl:AnnotationProperty .
-time:TemporalEntity a owl:Class .
-
 
 ssn-oms: a owl:Ontology ;
   dcterms:title "OMS Ontology - based on (SOSA) Ontology with SSN axiomatization"@en ;

--- a/ssn/rdf/ontology/extensions/ssn-system.ttl
+++ b/ssn/rdf/ontology/extensions/ssn-system.ttl
@@ -20,21 +20,6 @@
 @prefix ssn-system: <http://www.w3.org/ns/ssn/systems/> .
 
 
-voaf:Vocabulary a owl:Class .
-foaf:Agent a owl:Class .
-foaf:name a owl:AnnotationProperty .
-dcterms:title a owl:AnnotationProperty .
-dcterms:description a owl:AnnotationProperty .
-dcterms:rights a owl:AnnotationProperty .
-dcterms:license a owl:AnnotationProperty .
-dcterms:created a owl:AnnotationProperty .
-dcterms:creator a owl:AnnotationProperty .
-skos:definition a owl:AnnotationProperty .
-skos:example a owl:AnnotationProperty .
-vann:preferredNamespacePrefix a owl:AnnotationProperty .
-vann:preferredNamespaceUri a owl:AnnotationProperty .
-
-
 ssn-system: a owl:Ontology , voaf:Vocabulary ;
   dcterms:title "System capabilities, operating ranges, and survival ranges ontology"@en ;
   dcterms:description "This ontology describes system capabilities, operating ranges, and survival ranges."@en ;


### PR DESCRIPTION
These come from external vocabularies and do not need to be defined here (sometimes inconsistently, leading to OWL errors)

Closes #41 