### PR TITLE
better use xsd:decimal than xsd:double

### DIFF
--- a/ssn/rdf/examples/2017/2017ex10.ttl
+++ b/ssn/rdf/examples/2017/2017ex10.ttl
@@ -14,7 +14,7 @@
   sosa:madeBySensor <sensor/926> ; 
   sosa:hasResult [
      rdf:type qudt:QuantityValue ;
-     qudt:numericValue "22.4"^^xsd:double ;
+     qudt:numericValue "22.4"^^xsd:decimal ;
      qudt:hasUnit unit:KiloW-HR ] ;
   sosa:phenomenonTime [
     rdf:type time:Interval ;

--- a/ssn/rdf/examples/2017/2017ex11.ttl
+++ b/ssn/rdf/examples/2017/2017ex11.ttl
@@ -14,7 +14,7 @@
   sosa:madeBySensor <sensor/926> ; 
   sosa:hasResult [
      rdf:type qudt:QuantityValue ;
-     qudt:numericValue "22.4"^^xsd:double ;
+     qudt:numericValue "22.4"^^xsd:decimal ;
      qudt:hasUnit unit:KiloW-HR ] ;
   sosa:phenomenonTime [
     rdf:type time:Interval ;

--- a/ssn/rdf/examples/2017/2017ex12.ttl
+++ b/ssn/rdf/examples/2017/2017ex12.ttl
@@ -22,7 +22,7 @@
   sosa:madeBySensor <rangefinder/30> ;
   sosa:hasResult [ 
     qudt:hasUnit unit:M ; 
-    qudt:numericalValue "15.3"^^xsd:double ] .
+    qudt:numericalValue "15.3"^^xsd:decimal ] .
 
 # using SSN, one can explicitly link a property and its feature of interest.
  
@@ -42,7 +42,7 @@
   sosa:observedProperty  <tree/125/height> ;
   sosa:madeBySensor <rangefinder/30> ;
   sosa:hasResult [ 
-    qudt:numericValue "23.0"^^xsd:double ;
+    qudt:numericValue "23.0"^^xsd:decimal ;
     qudt:hasUnit unit:M ] .
 
 # using SSN, one can explicitly link a property and its feature of interest.

--- a/ssn/rdf/examples/2017/2017ex13.ttl
+++ b/ssn/rdf/examples/2017/2017ex13.ttl
@@ -22,7 +22,7 @@
   sosa:madeBySensor <rangefinder/30> ;
   sosa:hasResult [ 
     qudt:hasUnit unit:M ; 
-    qudt:numericalValue "15.3"^^xsd:double ] .
+    qudt:numericalValue "15.3"^^xsd:decimal ] .
 
 <tree/124>  rdf:type    sosa:FeatureOfInterest ;
   rdfs:label "tree #124"@en .
@@ -38,7 +38,7 @@
   sosa:observedProperty  <tree/125/height> ;
   sosa:madeBySensor <rangefinder/30> ;
   sosa:hasResult [ 
-    qudt:numericValue "23.0"^^xsd:double ;
+    qudt:numericValue "23.0"^^xsd:decimal ;
     qudt:hasUnit qunit:M ] .
 
 <tree/125>  rdf:type    sosa:FeatureOfInterest ;

--- a/ssn/rdf/examples/2017/2017ex14.ttl
+++ b/ssn/rdf/examples/2017/2017ex14.ttl
@@ -36,7 +36,7 @@
   sosa:observedProperty  <VCAB-DP1-BP-40#groundDisplacementSpeed> ;
   sosa:hasResult [
      rdf:type qudt:QuantityValue ;
-     qudt:numericValue "5e-4"^^xsd:double ;
+     qudt:numericValue "5e-4"^^xsd:decimal ;
      qudt:hasUnit unit:CentiM-PER-SEC ] ;
   sosa:resultTime "2017-04-18T08:23:00-07:00"^^xsd:dateTimeStamp .
 

--- a/ssn/rdf/examples/2017/2017ex15.ttl
+++ b/ssn/rdf/examples/2017/2017ex15.ttl
@@ -36,6 +36,6 @@
   sosa:observedProperty  <VCAB-DP1-BP-40#groundDisplacementSpeed> ;
   sosa:hasResult [
      rdf:type qudt:QuantityValue ;
-     qudt:numericValue "5e-4"^^xsd:double ;
+     qudt:numericValue "5e-4"^^xsd:decimal ;
      qudt:hasUnit unit:CentiM-PER-SEC ] ;
   sosa:resultTime "2017-04-18T08:23:00-07:00"^^xsd:dateTimeStamp .

--- a/ssn/rdf/examples/2017/2017ex21.ttl
+++ b/ssn/rdf/examples/2017/2017ex21.ttl
@@ -123,5 +123,5 @@
 <observation/1087#quality> rdf:type qudt:Quantity ;
   qudt:quantityValue [
     rdf:type qudt:QuantityValue ;
-    qudt:numericValue "98.4"^^xsd:double ;
+    qudt:numericValue "98.4"^^xsd:decimal ;
     qudt:hasUnit unit:PERCENT ] .

--- a/ssn/rdf/examples/apartment-134.ttl
+++ b/ssn/rdf/examples/apartment-134.ttl
@@ -15,7 +15,7 @@ ex:Observation_235714 rdf:type sosa:Observation ;
   sosa:madeBySensor ex:sensor_926 ; 
   sosa:hasResult [
      rdf:type qudt:QuantityValue ;
-     qudt:numericValue "22.4"^^xsd:double ;
+     qudt:numericValue "22.4"^^xsd:decimal ;
      qudt:hasUnit unit:Kilowatthour ] ;
   sosa:phenomenonTime [
     rdf:type time:Interval ;

--- a/ssn/rdf/examples/dht22.ttl
+++ b/ssn/rdf/examples/dht22.ttl
@@ -140,5 +140,5 @@ ex:observation_1087_quality
 ex:observation_1087_quality rdf:type qudt:Quantity ;
   qudt:quantityValue [
     rdf:type qudt:QuantityValue ;
-    qudt:numericValue "98.4"^^xsd:double ;
+    qudt:numericValue "98.4"^^xsd:decimal ;
     qudt:hasUnit unit:PERCENT ] .

--- a/ssn/rdf/examples/iphone_barometer-sosa.ttl
+++ b/ssn/rdf/examples/iphone_barometer-sosa.ttl
@@ -46,7 +46,7 @@ ex:Observation_346344 rdf:type sosa:Observation ;
   sosa:madeBySensor ex:sensor_35-207306-844818-0_BMP282 ;
   sosa:hasResult [
     rdf:type qudt:QuantityValue ;
-    qudt:numericValue "101936"^^xsd:double ;
+    qudt:numericValue "101936"^^xsd:decimal ;
     qudt:hasUnit unit:PA ] ;
   sosa:resultTime "2017-06-06T12:36:13+00:00"^^xsd:dateTime ;
 .

--- a/ssn/rdf/examples/seismograph.ttl
+++ b/ssn/rdf/examples/seismograph.ttl
@@ -40,7 +40,7 @@ ex:VCAB-DP1-BP-40_t2017-04-18T08%3A23%3A00-07%3A00 a sosa:Observation ;
   sosa:observedProperty ex:groundDisplacementSpeed ;
   sosa:hasResult [
      rdf:type qudt:QuantityValue ;
-     qudt:numericValue "5e-4"^^xsd:double ;
+     qudt:numericValue "5e-4"^^xsd:decimal ;
      qudt:hasUnit unit:CentiM-PER-SEC ] ;
   sosa:resultTime "2017-04-18T08:23:00-07:00"^^xsd:dateTimeStamp ;
 .

--- a/ssn/rdf/examples/tree-height.ttl
+++ b/ssn/rdf/examples/tree-height.ttl
@@ -22,7 +22,7 @@ ex:observation_1087 a sosa:Observation ;
   sosa:madeBySensor ex:rangefinder_30 ;
   sosa:hasResult [ 
     qudt:hasUnit unit:M ; 
-    qudt:numericValue "15.3"^^xsd:double ] ;
+    qudt:numericValue "15.3"^^xsd:decimal ] ;
 .
 ex:tree_124 a sosa:FeatureOfInterest ;
   rdfs:label "tree #124"@en ;

--- a/ssn/rdf/examples/unused/house134.ttl
+++ b/ssn/rdf/examples/unused/house134.ttl
@@ -136,7 +136,7 @@
 =======
 		qudt:unit unit:DegreeCelsius ;
 >>>>>>> 234-link-to-patterns
-		qudt:numericValue "22.9"^^xsd:double
+		qudt:numericValue "22.9"^^xsd:decimal
 	] .
 
 # The electric consumption in the kitchen of house #134 was 22.4 kWh as 

--- a/ssn/rdf/examples/unused/sosa-core_examples.ttl
+++ b/ssn/rdf/examples/unused/sosa-core_examples.ttl
@@ -52,7 +52,7 @@ ex:TempObservationResult1
   rdf:type sosa:Result ;
   rdfs:comment "The observed temperature for observation 1."^^xsd:string ;
   rdfs:label "Result of temperature observation 1."^^xsd:string ;
-  sosa:hasValue "23.8"^^xsd:double ;
+  sosa:hasValue "23.8"^^xsd:decimal ;
 .
 ex:TempObservation2
   rdf:type sosa:Observation ;
@@ -69,5 +69,5 @@ ex:TempObservationResult2
   rdf:type sosa:Result ;
   rdfs:comment "The observed temperature for observation 2."^^xsd:string ;
   rdfs:label "Result of temperature observation 2."^^xsd:string ;
-  sosa:hasValue "24.3"^^xsd:double ;
+  sosa:hasValue "24.3"^^xsd:decimal ;
 .

--- a/ssn/rdf/tests/Actuation/2017ex10.ttl
+++ b/ssn/rdf/tests/Actuation/2017ex10.ttl
@@ -20,7 +20,7 @@
   sosa:hasResult [
       a qudt:QuantityValue ;
       qudt:hasUnit unit:KiloW-HR ;
-      qudt:numericValue "22.4"^^xsd:double ;
+      qudt:numericValue "22.4"^^xsd:decimal ;
     ] ;
   sosa:madeBySensor <https://example.org/data/sensor/926> ;
   sosa:observedProperty <https://example.org/data/apartment/134/electricConsumption> ;

--- a/ssn/rdf/tests/Actuation/2017ex11.ttl
+++ b/ssn/rdf/tests/Actuation/2017ex11.ttl
@@ -14,7 +14,7 @@
   sosa:madeBySensor <sensor/926> ; 
   sosa:hasResult [
      rdf:type qudt:QuantityValue ;
-     qudt:numericValue "22.4"^^xsd:double ;
+     qudt:numericValue "22.4"^^xsd:decimal ;
      qudt:hasUnit unit:KiloW-HR ] ;
   sosa:phenomenonTime [
     rdf:type time:Interval ;

--- a/ssn/rdf/tests/FoI/2017ex14.ttl
+++ b/ssn/rdf/tests/FoI/2017ex14.ttl
@@ -37,7 +37,7 @@
   sosa:observedProperty  <VCAB-DP1-BP-40#groundDisplacementSpeed> ;
   sosa:hasResult [
      rdf:type qudt:QuantityValue ;
-     qudt:numericValue "5e-4"^^xsd:double ;
+     qudt:numericValue "5e-4"^^xsd:decimal ;
      qudt:hasUnit unit:CentiM-PER-SEC ] ;
   sosa:resultTime "2017-04-18T08:23:00-07:00"^^xsd:dateTimeStamp .
 

--- a/ssn/rdf/tests/Procedure/2017ex21.ttl
+++ b/ssn/rdf/tests/Procedure/2017ex21.ttl
@@ -124,5 +124,5 @@
 <observation/1087#quality> rdf:type qudt:Quantity ;
   qudt:quantityValue [
     rdf:type qudt:QuantityValue ;
-    qudt:numericValue "98.4"^^xsd:double ;
+    qudt:numericValue "98.4"^^xsd:decimal ;
     qudt:hasUnit unit:PERCENT ] .

--- a/ssn/rdf/tests/System/2017ex10.ttl
+++ b/ssn/rdf/tests/System/2017ex10.ttl
@@ -15,7 +15,7 @@
   sosa:madeBySensor <sensor/926> ; 
   sosa:hasResult [
      rdf:type qudt:QuantityValue ;
-     qudt:numericValue "22.4"^^xsd:double ;
+     qudt:numericValue "22.4"^^xsd:decimal ;
      qudt:hasUnit unit:KiloW-HR ] ;
   sosa:phenomenonTime [
     rdf:type time:Interval ;

--- a/ssn/rdf/tests/System/2017ex11.ttl
+++ b/ssn/rdf/tests/System/2017ex11.ttl
@@ -14,7 +14,7 @@
   sosa:madeBySensor <sensor/926> ; 
   sosa:hasResult [
      rdf:type qudt:QuantityValue ;
-     qudt:numericValue "22.4"^^xsd:double ;
+     qudt:numericValue "22.4"^^xsd:decimal ;
      qudt:hasUnit unit:KiloW-HR ] ;
   sosa:phenomenonTime [
     rdf:type time:Interval ;

--- a/ssn/rdf/tests/System/2017ex14.ttl
+++ b/ssn/rdf/tests/System/2017ex14.ttl
@@ -37,7 +37,7 @@
   sosa:observedProperty  <VCAB-DP1-BP-40#groundDisplacementSpeed> ;
   sosa:hasResult [
      rdf:type qudt:QuantityValue ;
-     qudt:numericValue "5e-4"^^xsd:double ;
+     qudt:numericValue "5e-4"^^xsd:decimal ;
      qudt:hasUnit unit:CentiM-PER-SEC ] ;
   sosa:resultTime "2017-04-18T08:23:00-07:00"^^xsd:dateTimeStamp .
 

--- a/ssn/rdf/tests/System/2017ex21.ttl
+++ b/ssn/rdf/tests/System/2017ex21.ttl
@@ -124,5 +124,5 @@
 <observation/1087#quality> rdf:type qudt:Quantity ;
   qudt:quantityValue [
     rdf:type qudt:QuantityValue ;
-    qudt:numericValue "98.4"^^xsd:double ;
+    qudt:numericValue "98.4"^^xsd:decimal ;
     qudt:hasUnit unit:PERCENT ] .


### PR DESCRIPTION
This is a rule of thumb. See 

> Keil, J. M., & Gänßinger, M. (2022, May). The Problem with XSD Binary Floating Point Datatypes in RDF. In European Semantic Web Conference (pp. 165-182). Cham: Springer International Publishing.