### PR TITLE
consistent definition of wikidata terms in ex namespace

### DIFF
--- a/ssn/rdf/examples/seismograph.ttl
+++ b/ssn/rdf/examples/seismograph.ttl
@@ -25,9 +25,10 @@ ex:VCAB-DP1-BP-40_location a sosa:Sample ;
     a geo:Point ;
     geo:asWKT "POINT (-120.6195831 35.8648067)"^^geo:WktLiteral ;
   ] ;
-  sosa:isSampleOf <https://www.wikidata.org/wiki/Q2> ;
+  sosa:isSampleOf ex:Earth ;
 .
-<https://www.wikidata.org/wiki/Q2> a sosa:FeatureOfInterest ;
+ex:Earth a sosa:FeatureOfInterest ;
+  owl:sameAs <https://www.wikidata.org/wiki/Q2> ;
   rdfs:label "Earth" ;
 .
 ex:groundDisplacementSpeed a sosa:Property ;

--- a/ssn/rdf/examples/sunspots.ttl
+++ b/ssn/rdf/examples/sunspots.ttl
@@ -13,7 +13,7 @@
 
 <Observation/7536> rdf:type sosa:Observation ;
   sosa:observedProperty  ex:sunspotCount ;
-  sosa:hasFeatureOfInterest <https://www.wikidata.org/wiki/Q525> ;
+  sosa:hasFeatureOfInterest ex:Sun ;
   sosa:hasSimpleResult 66 ;
   sosa:phenomenonTime [
     rdf:type time:Instant ;
@@ -23,6 +23,7 @@
 ex:sunspotCount rdf:type sosa:Property ;
   skos:broader qk:Count ;
 .
-<https://www.wikidata.org/wiki/Q525> a sosa:FeatureOfInterest ;
+ex:Sun a sosa:FeatureOfInterest ;
+  owl:sameAs <https://www.wikidata.org/wiki/Q525> .
   rdfs:label "Sun" ;
 .


### PR DESCRIPTION
For better homogeneity among examples, this PR defines ex:Sun and declares it as owl:sameAs the concept from wikidata 