### PR TITLE
Resolve syntax issues for respec's hljs and remove workaround

### DIFF
--- a/ssn/chapters/ModelTimes.html
+++ b/ssn/chapters/ModelTimes.html
@@ -36,7 +36,7 @@
 <pre class="example turtle" data-include="./rdf/examples/forecast.ttl" data-include-format="text"></pre>
 
 <h5>Serialised in JSON-LD</h5>
-<pre class="example" data-include="./rdf/examples/forecast.jsonld" data-include-format="text"></pre>
+<pre class="example json" data-include="./rdf/examples/forecast.jsonld" data-include-format="text"></pre>
 
 <p class="note">
     Other means to represent forecasts are reported, but not in the scope of this specification.

--- a/ssn/config.js
+++ b/ssn/config.js
@@ -1,3 +1,25 @@
+
+async function loadTurtle() {
+  // load the highlighter for turtle
+  const worker = await new Promise(resolve => {
+    require(["core/worker"], ({ worker }) => resolve(worker));
+  });
+  const action = "highlight-load-lang";
+  const langURL = new URL("./turtle.js", window.location).href;
+  const propName = "hljsDefineTurtle";
+  const lang = "turtle";
+  worker.postMessage({ action, langURL, propName, lang });
+  return new Promise(resolve => {
+    worker.addEventListener("message", function listener({ data }) {
+      const { action: responseAction, lang: responseLang } = data;
+      if (responseAction === action && responseLang === lang) {
+        worker.removeEventListener("message", listener);
+        resolve();
+      }
+    });
+  });
+}
+
 var respecConfig = {
   specStatus: "ED",
   shortName: "vocab-ssn-2023",
@@ -12,6 +34,9 @@ var respecConfig = {
   wgPublicList: "public-sdw-comments",
   // replace with pointer to GitHub issues list
   implementationReportURI: "https://w3c.github.io/sdw-sosa-ssn/ssn-usage/",
+  inlineCSS: true,
+  noIDLIn: true,
+  noLegacyStyle: false,
   noRecTrack: false,
   logos: [
     {
@@ -201,5 +226,6 @@ var respecConfig = {
         "publisher": "ETSI",
         "rawDate": "2024-01"
     }
-  }
+  },
+  preProcess: [ loadTurtle ]
 }

--- a/ssn/config.js
+++ b/ssn/config.js
@@ -34,9 +34,6 @@ var respecConfig = {
   wgPublicList: "public-sdw-comments",
   // replace with pointer to GitHub issues list
   implementationReportURI: "https://w3c.github.io/sdw-sosa-ssn/ssn-usage/",
-  inlineCSS: true,
-  noIDLIn: true,
-  noLegacyStyle: false,
   noRecTrack: false,
   logos: [
     {

--- a/ssn/index.html
+++ b/ssn/index.html
@@ -6,26 +6,6 @@
   <title>Semantic Sensor Network Ontology - 2023 Edition</title>
   <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
   <script class="remove" src="config.js"></script>
-
-  <!-- couldn't find a way to make turtle.js syntax in respec, so I'll do it manually here for now. Seeking help -->
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/a11y-light.min.css">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js"></script>
-  <script src="./turtle.js"></script>
-  <script>
-    // Register the Turtle language after turtle.js is loaded
-    hljs.registerLanguage("turtle", hljsDefineTurtle);
-  
-    // Highlight all code blocks on page load
-    window.addEventListener("load", function () {
-      console.log("load")
-
-      document.respec.ready.then(function () {
-        console.log(hljs)
-        hljs.highlightAll();
-      });
-    });
-  </script>
-
   <script src="https://www.w3.org/2007/OWL/toggles.js"></script>
   <script type="application/ld+json">TODO: ADD HERE JSON-LD VERSION OF THE ONTOLOGY</script>
   <script>

--- a/ssn/turtle.js
+++ b/ssn/turtle.js
@@ -20,7 +20,10 @@ function hljsDefineTurtle(hljs) {
     relevance: 1, // XML tags look also like relative IRIs
     begin: /</,
     end: />/,
-    illegal: /[^\x00-\x20<>"{}|^`]/, // TODO: https://www.w3.org/TR/turtle/#grammar-production-UCHAR
+    // Patch Note: The following RegExp has been inverted (i.e., [^...] changed to [...]).
+    // The original was lifted directly from the grammar, but the grammar specifies valid syntax,
+    // whereas `illegal` specifies the opposite, so every @prefix line was causing errors.
+    illegal: /[\x00-\x20<>"{}|^`]/, // TODO: https://www.w3.org/TR/turtle/#grammar-production-UCHAR
   };
   
   // https://www.w3.org/TR/turtle/#terminals


### PR DESCRIPTION
Fixes #372.

This resolves issues that were causing errors in ReSpec's highlight.js run, and backs out the separate instance that had been added as a workaround.

More details are provided in https://github.com/w3c/sdw-sosa-ssn/issues/372#issuecomment-3189165988.