### PR TITLE
Update worker reference to work for ReSpec 37

### DIFF
--- a/ssn/config.js
+++ b/ssn/config.js
@@ -1,9 +1,7 @@
 
 async function loadTurtle() {
   // load the highlighter for turtle
-  const worker = await new Promise(resolve => {
-    require(["core/worker"], ({ worker }) => resolve(worker));
-  });
+  const worker = await document.respec.worker;
   const action = "highlight-load-lang";
   const langURL = new URL("./turtle.js", window.location).href;
   const propName = "hljsDefineTurtle";

--- a/ssn/config.js
+++ b/ssn/config.js
@@ -96,6 +96,7 @@ var respecConfig = {
     },
     {
       name: "Krzysztof Janowicz",
+      w3cid: "43518",
       company: "Universität Wien, AT",
       companyURL: "https://www.univie.ac.at/",
       orcid: "0009-0003-1968-887X"


### PR DESCRIPTION
Fixes #455.

This updates how `worker` is referenced to work with the new way that ReSpec 37 exposes it now that `require` has been dropped.

This resolves the ReSpec error and as far as I can tell, the Turtle examples are highlighting, but I'll leave it to someone more familiar with what it's expected to look like to confirm.

Note: Looks like this fails CI for an unrelated reason (editor missing w3cid)