### PR TITLE
Small change to the definitions of System and Procedure

### DIFF
--- a/ssn/chapters/Actuation.html
+++ b/ssn/chapters/Actuation.html
@@ -51,7 +51,7 @@
         </p>
         <p>
             <em>Actuating Procedure</em> &mdash;
-            workflow, protocol, plan, algorithm, or computational method specifying how to make an Actuation
+            workflow, protocol, plan, algorithm, program, or computational method specifying how to make an Actuation
         </p>
         <p>
             An Actuating Procedure is re-usable, and might be applied in many Actuations.
@@ -324,7 +324,7 @@
             System that implements an ActuatingProcedure to change the value of an actuatable Property
         </p>
         <p>
-            This may be a device, a piece of infrastructure, an agent (including humans), or software (simulation).
+            This may be a device, a piece of infrastructure, an agent (including humans), or a software-based system, including systems performing simulations.
 
         </p>
         <p class="note">An Actuator may have a geographic location.

--- a/ssn/chapters/Common.html
+++ b/ssn/chapters/Common.html
@@ -529,7 +529,7 @@
             </p>
             <p>
                 <em>Procedure</em> &mdash;
-                workflow, protocol, plan, algorithm, or computational method specifying how to make an Execution
+                workflow, protocol, plan, algorithm, program, or computational method specifying how to make an Execution
             </p>
             <p>
                 A Procedure is re-usable, and might be applied in many Executions (Actuations, Observations, or

--- a/ssn/chapters/Observation.html
+++ b/ssn/chapters/Observation.html
@@ -297,7 +297,7 @@
         </p>
         <p>
             <em>Observing Procedure</em> &mdash;
-            workflow, protocol, plan, algorithm, or computational method specifying how to make an Observation
+            workflow, protocol, plan, algorithm, program, or computational method specifying how to make an Observation
         </p>
         <p>
             An Observing Procedure is re-usable, and might be applied in many Observations.
@@ -321,7 +321,7 @@
             <div>
                 <dt>Examples</dt>
                 <dd>
-                    A workflow, protocol, plan, algorithm, or computational method specifying how to make an
+                    A workflow, protocol, plan, algorithm, program, or computational method specifying how to make an
                     observation; the description of the process used by an observer.
                     This could be a chemical analysis method, a protocol for measuring an object, or even
                     a checklist used by a human observer during a biodiversity campaign.
@@ -364,7 +364,7 @@
             System that implements an ObservingProcedure to determine the value of an observable Property
         </p>
         <p>
-            This may be a device, a piece of infrastructure, an agent (including humans), or software (simulation).
+            This may be a device, a piece of infrastructure, an agent (including humans), or a software-based system, including systems performing simulations.
         </p>
         <p>
             A <a href="#SOSASensor">Sensor</a> responds to a <a href="#SOSAStimulus">Stimulus</a>,

--- a/ssn/chapters/Sampling.html
+++ b/ssn/chapters/Sampling.html
@@ -684,7 +684,7 @@
         </p>
         <p>
             <em>Sampling Procedure</em> &mdash;
-            workflow, protocol, plan, algorithm, or computational method specifying how to make a Sampling
+            workflow, protocol, plan, algorithm, program, or computational method specifying how to make a Sampling
         </p>
         <p>
             A Sampling Procedure is re-usable, and might be applied in many Samplings.

--- a/ssn/rdf/ontology/alignments/sosa-sdo.ttl
+++ b/ssn/rdf/ontology/alignments/sosa-sdo.ttl
@@ -85,7 +85,7 @@ sosa:Platform
 .
 sosa:Procedure
   rdf:type rdfs:Class ;
-  rdfs:comment "A workflow, protocol, plan, algorithm, or computational method specifying how to make an Observation, create a Sample, or make a change to the state of the world (via an Actuator). A Procedure is re-usable, and might be involved in many Observations, Samplings, or Actuations. It explains the steps to be carried out to arrive at reproducible results."@en ;
+  rdfs:comment "A workflow, protocol, plan, algorithm, program, or computational method specifying how to make an Observation, create a Sample, or make a change to the state of the world (via an Actuator). A Procedure is re-usable, and might be involved in many Observations, Samplings, or Actuations. It explains the steps to be carried out to arrive at reproducible results."@en ;
   rdfs:label "Procedure"@en ;
   rdfs:subClassOf schema:Intangible ;
   skos:editorialNote "Candidate for schema.org" ;
@@ -125,7 +125,7 @@ sosa:Sampling
 .
 sosa:Sensor
   rdf:type rdfs:Class ;
-  rdfs:comment "Device, agent (including humans), or software (simulation) involved in, or implementing, a Procedure. Sensors respond to a stimulus, e.g., a change in the environment, or input data composed from the results of prior Observations, and generate a Result. Sensors can be hosted by Platforms."@en ;
+  rdfs:comment "Device, agent (including humans), or a software-based system, including systems performing simulations involved in, or implementing, a Procedure. Sensors respond to a stimulus, e.g., a change in the environment, or input data composed from the results of prior Observations, and generate a Result. Sensors can be hosted by Platforms."@en ;
   rdfs:label "Sensor"@en ;
   rdfs:subClassOf schema:Thing ;
   skos:editorialNote "Candidate for schema.org" ;

--- a/ssn/rdf/ontology/core/sosa-actuation.ttl
+++ b/ssn/rdf/ontology/core/sosa-actuation.ttl
@@ -31,7 +31,7 @@ sosa:ActuatingProcedure
   rdfs:subClassOf sosa:Procedure ;
   rdfs:label "Actuating Procedure"@en ;
   skos:definition """
-  workflow, protocol, plan, algorithm, or computational method specifying how to make an Actuation
+  workflow, protocol, plan, algorithm, program, or computational method specifying how to make an Actuation
   
   An Actuating Procedure is re-usable, and might be applied in many Actuations.
   It explains the steps to be carried out to arrive at reproducible results.
@@ -90,7 +90,7 @@ sosa:Actuator
   skos:definition """
   System that implements an ActuatingProcedure to change the value of an actuatable Property
 
-  This may be a device, a piece of infrastructure, an agent (including humans), or software (simulation)."""@en ;
+  This may be a device, a piece of infrastructure, an agent (including humans), or a software-based system, including systems performing simulations."""@en ;
   skos:example "A window actuator for automatic window control, i.e., opening or closing the window."@en ;
   rdfs:isDefinedBy sosa-act: .
 

--- a/ssn/rdf/ontology/core/sosa-common.ttl
+++ b/ssn/rdf/ontology/core/sosa-common.ttl
@@ -138,7 +138,7 @@ sosa:Procedure
   a owl:Class ;
   rdfs:label "Procedure"@en ;
   skos:definition """
-  workflow, protocol, plan, algorithm, or computational method specifying how to make an Execution
+  workflow, protocol, plan, algorithm, program, or computational method specifying how to make an Execution
 
   A Procedure is re-usable, and might be applied in many Actuations, Observations, or Samplings.
   It explains the steps to be carried out to arrive at reproducible results.
@@ -574,7 +574,7 @@ sosa:System
   An Asset that implements a Procedure in the context of an Execution
   """@en ; 
   skos:note """
-  This may be a device, a piece of infrastructure, an agent (including humans), or software (simulation).
+  This may be a device, a piece of infrastructure, an agent (including humans), or a software-based system, including systems performing simulations.
 
   Different Systems can implement the same (reusable) Procedure for different Executions.
 

--- a/ssn/rdf/ontology/core/sosa-observation.ttl
+++ b/ssn/rdf/ontology/core/sosa-observation.ttl
@@ -80,12 +80,12 @@ sosa:ObservingProcedure
   rdfs:subClassOf sosa:Procedure ;
   rdfs:label "Observing Procedure"@en ;
   skos:definition """
-  workflow, protocol, plan, algorithm, or computational method specifying how to make an Observation
+  workflow, protocol, plan, algorithm, program, or computational method specifying how to make an Observation
 
   An Observing Procedure is re-usable, and might be involved in many Observations. 
   It explains the steps to be carried out to arrive at reproducible results.
   """@en ;
-  skos:example """A workflow, protocol, plan, algorithm, or computational method specifying how to make an observation; the description of the process used by an observer. This could be a chemical analysis method, a protocol for measuring an object, or even a checklist used by a human observer during a biodiversity campaign. The Procedure could further describe the algorithms behind simulators or models used to generate a result from other inputs."""@en ;
+  skos:example """A workflow, protocol, plan, algorithm, program, or computational method specifying how to make an observation; the description of the process used by an observer. This could be a chemical analysis method, a protocol for measuring an object, or even a checklist used by a human observer during a biodiversity campaign. The Procedure could further describe the algorithms behind simulators or models used to generate a result from other inputs."""@en ;
   skos:note """[ISO 19156:2023] An ObservingProcedure shall be defined as the description of steps performed in order to determine the value of an observableProperty by an Observer."""@en ;
   rdfs:isDefinedBy sosa-obs: .
 
@@ -99,7 +99,7 @@ sosa:Sensor
   skos:definition """
   System that implements an ObservingProcedure to determine the value of an observable Property
 
-  This may be a device, a piece of infrastructure, an agent (including humans), or software (simulation).
+  This may be a device, a piece of infrastructure, an agent (including humans), or a software-based system, including systems performing simulations.
 
   A Sensor responds to a stimulus, e.g., a change in the environment, or input data composed from the results of prior Observations.
   """@en ;

--- a/ssn/rdf/ontology/core/sosa-sampling.ttl
+++ b/ssn/rdf/ontology/core/sosa-sampling.ttl
@@ -173,7 +173,7 @@ sosa:SamplingProcedure
   rdfs:subClassOf sosa:Procedure ;
   rdfs:label "Sampling Procedure"@en ;
   skos:definition """
-  workflow, protocol, plan, algorithm, or computational method specifying how to make a Sampling
+  workflow, protocol, plan, algorithm, program, or computational method specifying how to make a Sampling
 
   A Sampling Procedure is re-usable, and might be involved in many Samplings. 
   It explains the steps to be carried out to arrive at reproducible results.

--- a/ssn/rdf/ontology/extensions/sosa-oms.ttl
+++ b/ssn/rdf/ontology/extensions/sosa-oms.ttl
@@ -225,7 +225,7 @@ sosa-oms:PreparationProcedure
   ogc-ms:implements <http://www.opengis.net/spec/om/3.0/req/sam-cpt/PreparationProcedure> ;
   rdfs:label "Preparation Procedure"@en ;
   skos:definition """
-  A workflow, protocol, plan, algorithm, or computational method specifying a step in preparing a Sample. 
+  A workflow, protocol, plan, algorithm, program, or computational method specifying a step in preparing a Sample. 
   A Preparation Procedure is re-usable, and might be involved in many preparations. 
   It explains the steps to be carried out to arrive at reproducible results.
   """@en ;


### PR DESCRIPTION
This PR proposes a small clarification of the definitions of `System` and `Procedure`, with particular attention to the interpretation of software-based systems.

It originates from a collaboration with a researcher at LUT University (Finland). In this context, a concrete Python script was initially intended to be modeled as a System (a “Calculation”), while the abstract notion of a “Task” that the script is meant to carry out (e.g., fatigue calculation) was modeled as a Procedure.

While this interpretation is understandable given the current definitions, I consider that the existing wording is not sufficiently precise and allows for ambiguity between systems as artifacts that perform computation and procedures as abstract specifications of computational or observational behaviour.

In my view, a Python script, like other software programs, is more appropriately modeled as a Procedure, since it encodes a computational method or algorithmic specification. The relationship between a concrete computational artifact (e.g., a script) and the abstract task it operationalizes can then be captured outside SSN/SOSA, for example using a UML-style notion such as _manifestation_, which relates an artifact to the specification it embodies.

Accordingly, this PR makes the following minimal changes:

- In the definition of `sosa:System` and its subclasses, it replaces “software (simulation)” with “or a software-based system, including systems performing simulations”
- In the definition of `sosa:Procedure` and its subclasses, it replaces “workflow, protocol, plan, algorithm, computational method” with “workflow, protocol, plan, algorithm, **program**, or computational method”

These changes aim to improve conceptual clarity.