### PR TITLE
HTML tabulation of SSN-DOLCE alignment

### DIFF
--- a/ssn/chapters/DOLCE-alignment.html
+++ b/ssn/chapters/DOLCE-alignment.html
@@ -1,0 +1,183 @@
+<h3>DOLCE Alignment Module</h3>
+<p>This section introduces the alignment of SOSA to the DOLCE upper ontology [[DOLCE]].
+  This serves to axiomatically clarify the intended meaning of SOSA terms and will assist SOSA users wishing to
+  interoperate with other DOLCE-aligned ontologies.
+  The DOLCE alignment can be used independently to align SOSA with more generic concepts/properties of DOLCE.
+</p>
+<p style="text-align: center;">
+  The ontology IRI of the DOLCE Alignment module is
+  <a href="http://www.w3.org/ns/sosa/dolce">http://www.w3.org/ns/sosa/dolce</a><br>
+  The version IRI of the DOLCE Alignment module 2023 edition is
+  <a href="http://www.w3.org/ns/sosa/2023/dolce">http://www.w3.org/ns/sosa/2023/dolce</a>
+</p>
+
+<section id="DOLCE_Alignment-namespaces">
+  <h4>Namespaces</h4>
+  <p>The following namespace prefixes are used in the alignment of SOSA to DOLCE.</p>
+  <dl>
+    <dt>sosa:</dt>
+    <dd>
+      <a href="http://www.w3.org/ns/sosa/">http://www.w3.org/ns/sosa/</a>
+    </dd>
+    <dt>db:</dt>
+    <dd>
+      <a href="https://w3id.org/DOLCE/OWL/DOLCEbasic#">https://w3id.org/DOLCE/OWL/DOLCEbasic#</a>
+    </dd>
+  </dl>
+</section>
+<section id="DOLCE-Class-Alignments">
+  <h4>Class Alignments</h4>
+  <p>The upper-level classes from SOSA are aligned with the DOLCE classes as follows.
+    The alignment of subclasses of these upper-level classes follows logically from these correspondences.
+  </p>
+  <p class="note">
+    The notation used in this section is described in <a href="#Alignment-notation"></a>.
+  </p>
+  <p class="note">
+    The definition of each DOLCE concept is displayed as a tooltip when hovering over the concept.
+  </p>
+  <ul class="align-on-symbol">
+    <li>
+      <span class="lhs"><a>sosa:Asset</a></span>
+      <span class="symbol logic">⊑</span>
+      <span class="rhs">
+        <span
+          title="A Physical Object is a physical endurant with unity criterion (examples: a person, a human body, a house, a computer).">db:PhysicalObject</span>
+        <span class="logic">or</span>
+        <span
+          title="A Social Object is a non-physical object which is generically dependent on a community of agents (examples: a person in the legal sense, a client, a law, an economic system).">db:SocialObject</span>
+      </span>
+    </li>
+    <li>
+      <span class="lhs"><a>sosa:Deployment</a></span>
+      <span class="symbol logic">⊑</span>
+      <span class="rhs">
+        <span
+          title="An Event is an anti-cumulative perdurant, i.e., a perdurant that when summed to another perdurant of the same type, gives a perdurant of a different type (examples: closing a door, reaching the top of a mountain, breaking a seal).">db:Event</span>
+        <span class="logic">and</span>
+        <span>
+          (
+          <span
+            title="An Accomplishment is an event which is mereologically non-atomic (examples: a conference, an ascent, a performance).">db:Accomplishment</span>
+          <span class="logic">or</span>
+          <span
+            title="An Achievement is an event which is mereologically atomic (examples: reaching the summit of K2, a departure, a death).">db:Achievement</span>
+          )
+        </span>
+      </span>
+    </li>
+    <li>
+      <span class="lhs"><a>sosa:Execution</a></span>
+      <span class="symbol logic">⊑</span>
+      <span class="rhs">
+        <span
+          title="An Event is an anti-cumulative perdurant, i.e., a perdurant that when summed to another perdurant of the same type, gives a perdurant of a different type (examples: closing a door, reaching the top of a mountain, breaking a seal).">db:Event</span>
+        <span class="logic">and</span>
+        <span>
+          (
+          <span
+            title="An Accomplishment is an event which is mereologically non-atomic (examples: a conference, an ascent, a performance).">db:Accomplishment</span>
+          <span class="logic">or</span>
+          <span
+            title="An Achievement is an event which is mereologically atomic (examples: reaching the summit of K2, a departure, a death).">db:Achievement</span>
+          )
+        </span>
+      </span>
+    </li>
+    <li>
+      <span class="lhs"><a>sosa:ExecutionCollection</a></span>
+      <span class="symbol logic">⊑</span>
+      <span class="rhs">
+        <span
+          title="A Perdurant is an entity that happens in time (examples: a person’s life, a soccer game, the reading of a book, the state of feeling happy). Some perdurants are temporally atomic (example: the change of a letter’s state due to the breaking of the seal).">db:Perdurant</span>
+    </li>
+    <li>
+      <span class="lhs"><a>sosa:FeatureOfInterest</a></span>
+      <span class="symbol logic">⊑</span>
+      <span class="rhs">
+        <span
+          title="An Endurant is an entity wholly present, i.e., all its proper parts are present, at any time that it is present (examples: a person, a tree, an atom, an idea).">db:Endurant</span>
+        <span class="logic">or</span>
+        <span
+          title="A Perdurant is an entity that happens in time (examples: a person’s life, a soccer game, the reading of a book, the state of feeling happy). Some perdurants are temporally atomic (example: the change of a letter’s state due to the breaking of the seal).">db:Perdurant</span>
+      </span>
+    </li>
+    <li>
+      <span class="lhs"><a>sosa:MaterialSample</a></span>
+      <span class="symbol logic">⊑</span>
+      <span class="rhs">
+        <span
+          title="An Amount Of Matter is a physical endurant which has no unity criterion and is mereologically invariant, that is, all its part are essential parts (examples: the gold of my wedding ring, the sand used to make this glass).">db:AmountOfMatter</span>
+        <span class="logic">or</span>
+        <span
+          title="A Physical Object is a physical endurant with unity criterion (examples: a person, a human body, a house, a computer).">db:PhysicalObject</span>
+      </span>
+    </li>
+    <li>
+      <span class="lhs"><a>sosa:Procedure</a></span>
+      <span class="symbol logic">⊑</span>
+      <span class="rhs">
+        <span
+          title="A Non-Agentive Social Object is a social object to which intentions, believes and desires are not ascribed (examples: a law, an economic system, a currency, an asset).">db:NonAgentiveSocialObject</span>
+      </span>
+    </li>
+    <li>
+      <span class="lhs"><a>sosa:Property</a></span>
+      <span class="symbol logic">⊑</span>
+      <span class="rhs">
+        <span
+          title="A Quality is an entity that inheres in an endurant or a perdurant, and that can be perceived or measured (examples: the shape of a book, the color of a car, the size of a t-shirt, the electrical charge of a battery).">db:Quality</span>
+        <span class="logic">or</span>
+        <span
+          title="A Region is an abstract entity classified by a quality type and with mereological structure, the sum of all the regions of a quality type is called a quality space (examples: the color red is a region in the quality space of color, the red of a rose is a (sub)region of the red region in the quality space of color, the commercial value of 1 Euro is a region in the quality space of commercial values).">db:Region</span>
+      </span>
+    </li>
+    <li>
+      <span class="lhs"><a>sosa:Sample</a></span>
+      <span class="symbol logic">⊑</span>
+      <span class="rhs">
+        <span
+          title="An Endurant is an entity wholly present, i.e., all its proper parts are present, at any time that it is present (examples: a person, a tree, an atom, an idea).">db:Endurant</span>
+        <span class="logic">or</span>
+        <span
+          title="A Perdurant is an entity that happens in time (examples: a person’s life, a soccer game, the reading of a book, the state of feeling happy). Some perdurants are temporally atomic (example: the change of a letter’s state due to the breaking of the seal).">db:Perdurant</span>
+      </span>
+    </li>
+    <li>
+      <span class="lhs"><a>sosa:SampleCollection</a></span>
+      <span class="symbol logic">⊑</span>
+      <span class="rhs">
+        <span
+          title="An Endurant is an entity wholly present, i.e., all its proper parts are present, at any time that it is present (examples: a person, a tree, an atom, an idea).">db:Endurant</span>
+        <span class="logic">or</span>
+        <span
+          title="A Perdurant is an entity that happens in time (examples: a person’s life, a soccer game, the reading of a book, the state of feeling happy). Some perdurants are temporally atomic (example: the change of a letter’s state due to the breaking of the seal).">db:Perdurant</span>
+      </span>
+    </li>
+    <li>
+      <span class="lhs"><a>sosa:SpatialSample</a></span>
+      <span class="symbol logic">⊑</span>
+      <span class="rhs">
+        <span
+          title="A Feature is a physical endurant which has a unity criterion and is existentially dependent on another physical endurant, its host (examples: a hole, a bump, an object’s boundary, a stain on a t-shirt).">db:Feature</span>
+      </span>
+    </li>
+    <li>
+      <span class="lhs"><a>sosa:Stimulus</a></span>
+      <span class="symbol logic">⊑</span>
+      <span class="rhs">
+        <span
+          title="An Event is an anti-cumulative perdurant, i.e., a perdurant that when summed to another perdurant of the same type, gives a perdurant of a different type (examples: closing a door, reaching the top of a mountain, breaking a seal).">db:Event</span>
+        <span class="logic">and</span>
+        <span>
+          (
+          <span
+            title="An Accomplishment is an event which is mereologically non-atomic (examples: a conference, an ascent, a performance).">db:Accomplishment</span>
+          <span class="logic">or</span>
+          <span
+            title="An Achievement is an event which is mereologically atomic (examples: reaching the summit of K2, a departure, a death).">db:Achievement</span>
+          )
+        </span>
+    </li>
+  </ul>
+</section>

--- a/ssn/index.html
+++ b/ssn/index.html
@@ -184,9 +184,11 @@
 
     <section id="OBOE-alignment" data-include="./chapters/OBOE-alignment.html"></section>
 
+    <section id="IDO-alignment" data-include="./chapters/IDO-alignment.html"></section>
+
     <section id="DUL-alignment" data-include="./chapters/DUL-alignment.html"></section>
 
-    <section id="IDO-alignment" data-include="./chapters/IDO-alignment.html"></section>
+    <section id="DOLCE-alignment" data-include="./chapters/DOLCE-alignment.html"></section>
 
     <section id="BFO-alignment" data-include="./chapters/BFO-alignment.html"></section>
 


### PR DESCRIPTION
Copy TTL alignment into HTML table

Closes #463

Preview: https://raw.githack.com/w3c/sdw-sosa-ssn/414-dolce-alignment/ssn/index.html#DOLCE-alignment
@kjano please check this. I merged the RDF/TTL alignment before I realised that the HTML representation was missing. 