### PR TITLE
New copyright statement including OGC and software license

### DIFF
--- a/ssn/index.html
+++ b/ssn/index.html
@@ -77,7 +77,7 @@
 </head>
 
 <body>
-  <p><a href='https://www.ogc.org/ogc/document'>OGC</a> document use rules also apply.  </p>
+  <p class=copyright><a href="https://www.w3.org/policies/#copyright">Copyright</a> © 2026 <a href="http://www.opengeospatial.org/">OGC</a> &amp; <a href="https://www.w3.org/"> World Wide Web Consortium</a>, <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/policies/#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/policies/#W3C_Trademarks">trademark</a>, <a href="https://www.w3.org/copyright/software-license/">W3C</a> and <a href="https://www.ogc.org/ogc/document">OGC</a> document use rules apply.</p>
   <section id="abstract">
     <p>
       The Semantic Sensor Network ontology (SSN) describes actuators and their actuations, sensors and their

--- a/ssn/usage/index.html
+++ b/ssn/usage/index.html
@@ -12,18 +12,13 @@
 </head>
 
 <body>
-  <p class='copyright'><a href='https://www.w3.org/Consortium/Legal/ipr-notice#Copyright'>Copyright</a> © 2026
-    <a href='http://www.opengeospatial.org/'>OGC</a> &amp;
-    <a href='https://www.w3.org/'> <abbr title='World Wide Web Consortium'>W3C</abbr> </a><sup>®</sup>
-    (<a href='https://www.csail.mit.edu/'><abbr title='Massachusetts Institute of Technology'>MIT</abbr></a>,
-    <a href='https://www.ercim.eu/'><abbr title='European Research Consortium for Informatics and Mathematics'>ERCIM</abbr></a>,
-    <a href='https://www.keio.ac.jp/'>Keio</a>, <a href='https://ev.buaa.edu.cn/'>Beihang</a>), <abbr
-      title='World Wide Web Consortium'>W3C</abbr>
-    <a href='https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer'>liability</a>,
-    <a href='https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks'>trademark</a>,
-    <a href='https://www.w3.org/Consortium/Legal/copyright-documents'>W3C</a> and
-    <a href='https://www.ogc.org/ogc/document'>OGC</a> document use rules apply.
-  </p>
+  <p class=copyright><a href="https://www.w3.org/policies/#copyright">Copyright</a> © 2026
+    <a href="http://www.opengeospatial.org/">OGC</a> &amp; <a href="https://www.w3.org/"> World Wide Web Consortium</a>,
+    <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
+    <a href="https://www.w3.org/policies/#Legal_Disclaimer">liability</a>,
+    <a href="https://www.w3.org/policies/#W3C_Trademarks">trademark</a>,
+    <a href="https://www.w3.org/copyright/software-license/">W3C</a> and
+    <a href="https://www.ogc.org/ogc/document">OGC</a> document use rules apply.</p>
   <section id="abstract">
     <p>This document provides an analysis of the usage of the SSN Ontology.
       This edition adds usage information for terms added to SSN in the 2023 update [[vocab-ssn-2023]]. </p>


### PR DESCRIPTION
The precise text of the copyright statement that the W3C webmaster proposes to add to the Echidna/Specberus rules for automated publication of the vocab-ssn-2023 specification. It has all the links to OCC and W3C usage rules and a link to the W3C software license (instead of the document license that was on the previous editors' draft), because that license is what the SDW charter says to use.