### PR TITLE
Cite every module by its ontology IRI and its version IRI

### DIFF
--- a/ssn/chapters/Alignment-BFO.html
+++ b/ssn/chapters/Alignment-BFO.html
@@ -15,6 +15,12 @@
   CCO provides modules for several sets of common concepts that may then be used in many application domains.
   This includes specializations of the BFO classes that align with classes from SSN.
 </p>
+<p style="text-align: center;">
+  The ontology IRI of the BFO/CCO Alignment module is
+  <a href="http://www.w3.org/ns/sosa/bfo">http://www.w3.org/ns/sosa/bfo</a><br>
+  The version IRI of the BFO/CCO Alignment module 2023 edition is
+  <a href="http://www.w3.org/ns/sosa/2023/bfo">http://www.w3.org/ns/sosa/2023/bfo</a>
+</p>
 
 <section id="BFO_Alignment_ns">
   <h4>Namespaces</h4>

--- a/ssn/chapters/Alignment-IDO.html
+++ b/ssn/chapters/Alignment-IDO.html
@@ -5,9 +5,11 @@
   This serves to axiomatically clarify the intended meaning of SSN terms in terms of IDO and enable usage of SSN and
   SOSA with IDO-aligned ontologies.
 </p>
-<p>
-  An RDF file containing a <a href="https://github.com/w3c/sdw-sosa-ssn/blob/gh-pages/ssn/rdf/ontology/alignments/sosa-ido.ttl">graph
-    corresponding to this alignment is available</a>.
+<p style="text-align: center;">
+  The ontology IRI of the IDO Alignment module is
+  <a href="http://www.w3.org/ns/sosa/ido">http://www.w3.org/ns/sosa/ido</a><br>
+  The version IRI of the IDO Alignment module 2023 edition is
+  <a href="http://www.w3.org/ns/sosa/2023/ido">http://www.w3.org/ns/sosa/2023/ido</a>
 </p>
 
 <section id="IDO_Alignment-namespaces">

--- a/ssn/chapters/RDF-implementation.html
+++ b/ssn/chapters/RDF-implementation.html
@@ -59,32 +59,57 @@
 <section id="distribution">
     <h4>Distribution</h4>
 
+    <p>
+        Each module is published as an RDF graph that is identified both by an ontology IRI and by a version IRI.
+        The ontology IRI denotes the module itself, and resolves to the edition that W3C recommends for new adoption,
+        which may be a later edition than this one.
+        The version IRI denotes the 2023 Edition of the module, and keeps resolving to the graph this document
+        specifies.
+        Both IRIs are given for every module of this edition: the core modules below, and the extension and
+        alignment modules in the section that documents each of them.
+    </p>
+
     <section id="SOSAdistribution">
         <h5>SOSA</h5>
 
         <p style="text-align: center;">
-            The SOSA graph contains the core definitions.
+            The SOSA graph contains the core definitions, and imports the SOSA modules below.
             <br>The ontology IRI of SOSA is <a href="http://www.w3.org/ns/sosa/">http://www.w3.org/ns/sosa/</a>.
             <br>The version IRI of SOSA 2023 edition is
             <a href="http://www.w3.org/ns/sosa/2023/">http://www.w3.org/ns/sosa/2023/</a>.
         </p>
 
         <p style="text-align: center;">
-            SOSA Common is available at
+            The ontology IRI of SOSA Common is
             <a href="http://www.w3.org/ns/sosa/common/">http://www.w3.org/ns/sosa/common/</a>.
+            <br>The version IRI of SOSA Common 2023 edition is
+            <a href="http://www.w3.org/ns/sosa/2023/common/">http://www.w3.org/ns/sosa/2023/common/</a>.
         </p>
         <p style="text-align: center;">
-            SOSA Actuation is available at <a href="http://www.w3.org/ns/sosa/act/">http://www.w3.org/ns/sosa/act/</a>.
+            The ontology IRI of SOSA Actuation is
+            <a href="http://www.w3.org/ns/sosa/act/">http://www.w3.org/ns/sosa/act/</a>.
+            <br>The version IRI of SOSA Actuation 2023 edition is
+            <a href="http://www.w3.org/ns/sosa/2023/act/">http://www.w3.org/ns/sosa/2023/act/</a>.
         </p>
         <p style="text-align: center;">
-            SOSA Observation is available at
+            The ontology IRI of SOSA Observation is
             <a href="http://www.w3.org/ns/sosa/obs/">http://www.w3.org/ns/sosa/obs/</a>.
+            <br>The version IRI of SOSA Observation 2023 edition is
+            <a href="http://www.w3.org/ns/sosa/2023/obs/">http://www.w3.org/ns/sosa/2023/obs/</a>.
         </p>
         <p style="text-align: center;">
-            SOSA Sampling is available at <a href="http://www.w3.org/ns/sosa/sam/">http://www.w3.org/ns/sosa/sam/</a>.
+            The ontology IRI of SOSA Sampling is
+            <a href="http://www.w3.org/ns/sosa/sam/">http://www.w3.org/ns/sosa/sam/</a>.
+            <br>The version IRI of SOSA Sampling 2023 edition is
+            <a href="http://www.w3.org/ns/sosa/2023/sam/">http://www.w3.org/ns/sosa/2023/sam/</a>.
         </p>
         <p style="text-align: center;">
-            The complete SOSA is available at <a href="http://www.w3.org/ns/sosa/">http://www.w3.org/ns/sosa/</a>.
+            SOSA Deprecated retains the terms of the `sosa:` namespace that were defined in a previous edition and are
+            deprecated in this edition.
+            <br>The ontology IRI of SOSA Deprecated is
+            <a href="http://www.w3.org/ns/sosa/dep/">http://www.w3.org/ns/sosa/dep/</a>.
+            <br>The version IRI of SOSA Deprecated 2023 edition is
+            <a href="http://www.w3.org/ns/sosa/2023/dep/">http://www.w3.org/ns/sosa/2023/dep/</a>.
         </p>
     </section>
 
@@ -92,32 +117,51 @@
         <h5>SSN</h5>
 
         <p style="text-align: center;">
-            The SSN graph contains the full axiomatization of the core terms.
+            The SSN graph contains the full axiomatization of the core terms, and imports SOSA and the SSN modules below.
             <br>The ontology IRI of SSN is <a href="http://www.w3.org/ns/ssn/">http://www.w3.org/ns/ssn/</a>.
             <br>The version IRI of SSN 2023 edition is
             <a href="http://www.w3.org/ns/ssn/2023/">http://www.w3.org/ns/ssn/2023/</a>.
         </p>
 
         <p style="text-align: center;">
-            SSN Common is available at <a href="http://www.w3.org/ns/ssn/common/">http://www.w3.org/ns/ssn/common/</a>.
+            The ontology IRI of SSN Common is
+            <a href="http://www.w3.org/ns/ssn/common/">http://www.w3.org/ns/ssn/common/</a>.
+            <br>The version IRI of SSN Common 2023 edition is
+            <a href="http://www.w3.org/ns/ssn/2023/common/">http://www.w3.org/ns/ssn/2023/common/</a>.
         </p>
         <p style="text-align: center;">
-            SSN Actuation is available at <a href="http://www.w3.org/ns/ssn/act/">http://www.w3.org/ns/ssn/act/</a>.
+            The ontology IRI of SSN Actuation is
+            <a href="http://www.w3.org/ns/ssn/act/">http://www.w3.org/ns/ssn/act/</a>.
+            <br>The version IRI of SSN Actuation 2023 edition is
+            <a href="http://www.w3.org/ns/ssn/2023/act/">http://www.w3.org/ns/ssn/2023/act/</a>.
         </p>
         <p style="text-align: center;">
-            SSN Observation is available at <a href="http://www.w3.org/ns/ssn/obs/">http://www.w3.org/ns/ssn/obs/</a>.
+            The ontology IRI of SSN Observation is
+            <a href="http://www.w3.org/ns/ssn/obs/">http://www.w3.org/ns/ssn/obs/</a>.
+            <br>The version IRI of SSN Observation 2023 edition is
+            <a href="http://www.w3.org/ns/ssn/2023/obs/">http://www.w3.org/ns/ssn/2023/obs/</a>.
         </p>
         <p style="text-align: center;">
-            SSN Sampling is available at <a href="http://www.w3.org/ns/ssn/sam/">http://www.w3.org/ns/ssn/sam/</a>.
+            The ontology IRI of SSN Sampling is
+            <a href="http://www.w3.org/ns/ssn/sam/">http://www.w3.org/ns/ssn/sam/</a>.
+            <br>The version IRI of SSN Sampling 2023 edition is
+            <a href="http://www.w3.org/ns/ssn/2023/sam/">http://www.w3.org/ns/ssn/2023/sam/</a>.
+        </p>
+        <p style="text-align: center;">
+            SSN Deprecated retains the terms of the `ssn:` namespace that have an equivalent in the `sosa:` namespace
+            and are deprecated in this edition.
+            <br>The ontology IRI of SSN Deprecated is
+            <a href="http://www.w3.org/ns/ssn/dep/">http://www.w3.org/ns/ssn/dep/</a>.
+            <br>The version IRI of SSN Deprecated 2023 edition is
+            <a href="http://www.w3.org/ns/ssn/2023/dep/">http://www.w3.org/ns/ssn/2023/dep/</a>.
         </p>
 
         <p class="note">
-            The RDF files of the 2017 edition remain available at their permanent version IRI, which is obtained by
+            The version IRI of a module is obtained from its ontology IRI by inserting the edition after
+            <code>/sosa</code> or <code>/ssn</code>.
+            The RDF files of the 2017 edition likewise remain available at their permanent version IRI, obtained by
             replacing <code>/sosa</code> with <code>/sosa/2017</code>, and <code>/ssn</code> with
             <code>/ssn/2017</code>.
-            Similarly, the RDF files of the 2023 edition will remain available at their permanent version IRI, which is
-            obtained by replacing <code>/sosa</code> with <code>/sosa/2023</code>, and <code>/ssn</code> with
-            <code>/ssn/2023</code>.
         </p>
     </section>
 


### PR DESCRIPTION
## Why

The 2017 Edition named its modules by their ontology IRI alone. Those IRIs resolve to the edition W3C recommends for new adoption, so a reader of REC-vocab-ssn-20171019 who follows them lands on the 2023 graphs, with nothing in the document saying so. Repairing that costs an in-place amendment of the 2017 Recommendation — a status-banner request to the Webmaster carrying a module-by-module list of where the 2017 graphs went.

This PR makes sure the 2023 Edition does not put the next edition in the same position: every module is cited by **both** its ontology IRI (which follows the current edition) and its version IRI (which is permanent and always denotes the 2023 Edition).

## What changed

Most modules already gave both IRIs. This completes the ones that did not:

- **`ssn/chapters/RDF-implementation.html`, § Distribution** — the eight lower-level core modules (SOSA/SSN Common, Actuation, Observation, Sampling) gave only an "is available at" IRI; they now give the ontology IRI and the version IRI, in the form already used by SOSA and SSN. A lead-in paragraph states what the two IRIs are for. The closing note now states the rule (insert the edition after `/sosa` or `/ssn`) instead of spelling out the 2023 substitution twice.
- **`ssn/chapters/Alignment-BFO.html`** and **`ssn/chapters/Alignment-IDO.html`** — added the two-IRI paragraph these two alignments were missing, in the same form as PROV, SAREF, OBOE, DUL and DOLCE. In the IDO section it replaces a link to a `blob/gh-pages` URL in this repository, which is not a stable citation for a published graph.

## Points for review

1. **The two graphs of deprecated terms** (`.../sosa/dep/` and `.../ssn/dep/`) are now listed in § Distribution. They are imported by SOSA and by SSN, so a tool following `owl:imports` reaches them, but the document did not name them anywhere before. Drop them if the WG prefers not to document them.
2. **The RDF files still declare `owl:versionIRI` on only three ontologies** (`sosa.ttl`, `ssn.ttl`, `sample-relations.ttl`), while the document now asserts a version IRI for all of them. Making the RDF self-describing is the natural follow-up, but it belongs with the wider question of version metadata (`owl:priorVersion`, `owl:deprecated` on what has no successor in 2023), so it is not in this PR.
3. Two places state both IRIs in different words and are left alone: the sample vocabularies in § System Capabilities say "available at … with permanent IRI …". Worth unifying at some point, though the wording there is about the graph rather than the ontology IRI, which carries a `#`.
4. `sosa-sdo.ttl` declares `https://example.org/sosa-sdo-mapping` and has no home under `/ns/sosa/` or `/ns/ssn/`. It is not documented in the specification either, so it is untouched here.

## Checks

`ssn/scripts/check_repository.py` produces byte-identical output before and after the change. A script over the RDF confirms that every ontology declared under `/ns/sosa/` or `/ns/ssn/` in `ssn/rdf/` now has both its ontology IRI and its 2023 version IRI cited somewhere in `ssn/index.html` or `ssn/chapters/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
