### PR TITLE
Say in RDF which edition of each module is current

### DIFF
--- a/ssn/rdf/ontology/alignments/sosa-bfo.ttl
+++ b/ssn/rdf/ontology/alignments/sosa-bfo.ttl
@@ -12,6 +12,7 @@
 @prefix sosa: <http://www.w3.org/ns/sosa/> .
 @prefix sp: <http://www.w3.org/ns/sosa/prov/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 
 
 cco:ont00000357 # "Act of Motion"
@@ -126,6 +127,10 @@ sosa:wasOriginatedBy
 .
 sosa:bfo
   rdf:type owl:Ontology ;
+  owl:versionIRI <http://www.w3.org/ns/sosa/2023/bfo> ;
+  dcat:version "2023" ;
+  dcat:hasVersion <http://www.w3.org/ns/sosa/2023/bfo> ;
+  dcat:hasCurrentVersion <http://www.w3.org/ns/sosa/2023/bfo> ;
   dcterms:created "2025-10-23"^^xsd:date ;
   dcterms:modified "2026-06-09"^^xsd:date ;
   dcterms:creator "Simon J D Cox" ;

--- a/ssn/rdf/ontology/alignments/sosa-dolce.ttl
+++ b/ssn/rdf/ontology/alignments/sosa-dolce.ttl
@@ -10,9 +10,14 @@
 @prefix vann: <http://purl.org/vocab/vann/> .
 @prefix voaf: <http://purl.org/vocommons/voaf#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @base <http://www.w3.org/ns/sosa/dolce#> .
 
 <http://www.w3.org/ns/sosa/dolce> rdf:type owl:Ontology ;
+  owl:versionIRI <http://www.w3.org/ns/sosa/2023/dolce> ;
+  dcat:version "2023" ;
+  dcat:hasVersion <http://www.w3.org/ns/sosa/2023/dolce> ;
+  dcat:hasCurrentVersion <http://www.w3.org/ns/sosa/2023/dolce> ;
                                    owl:imports sosa: ,
                                                <https://w3id.org/DOLCE/OWL/DOLCEbasic> ;
                                    dcterms:created "2026-06-02" ;

--- a/ssn/rdf/ontology/alignments/sosa-dul.ttl
+++ b/ssn/rdf/ontology/alignments/sosa-dul.ttl
@@ -9,9 +9,15 @@
 @prefix dul: <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#> .
 
 @prefix sosa: <http://www.w3.org/ns/sosa/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 
 
 <http://www.w3.org/ns/sosa/dul> rdf:type owl:Ontology ;
+  owl:versionIRI <http://www.w3.org/ns/sosa/2023/dul> ;
+  dcat:version "2023" ;
+  dcat:hasVersion <http://www.w3.org/ns/sosa/2023/dul> ;
+  dcat:hasCurrentVersion <http://www.w3.org/ns/sosa/2023/dul> ;
+  dcterms:replaces <http://www.w3.org/ns/ssn/dul> ;
   dcterms:creator "Maxime Lefrançois" ;
   dcterms:creator [
       rdf:type foaf:Agent ;

--- a/ssn/rdf/ontology/alignments/sosa-ido.ttl
+++ b/ssn/rdf/ontology/alignments/sosa-ido.ttl
@@ -7,9 +7,14 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix sosa: <http://www.w3.org/ns/sosa/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @base <http://www.w3.org/ns/sosa/ido> .
 
 sosa:ido rdf:type owl:Ontology ;
+  owl:versionIRI <http://www.w3.org/ns/sosa/2023/ido> ;
+  dcat:version "2023" ;
+  dcat:hasVersion <http://www.w3.org/ns/sosa/2023/ido> ;
+  dcat:hasCurrentVersion <http://www.w3.org/ns/sosa/2023/ido> ;
   dcterms:created "2025-11-06"^^xsd:date ;
   dcterms:creator "Johan Klüwer" ;
   dcterms:creator "Maja Milicic Brandt" ;

--- a/ssn/rdf/ontology/alignments/sosa-oboe.ttl
+++ b/ssn/rdf/ontology/alignments/sosa-oboe.ttl
@@ -11,6 +11,7 @@
 @prefix sosa: <http://www.w3.org/ns/sosa/> .
 @prefix sosa-obs: <http://www.w3.org/ns/sosa/obs/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 
 oboe-core:Characteristic
   owl:equivalentClass sosa:Property ;
@@ -95,6 +96,13 @@ sosa:hasFeatureOfInterest
 .
 sosa:oboe
   a owl:Ontology ;
+  owl:versionIRI <http://www.w3.org/ns/sosa/2023/oboe> ;
+  dcat:version "2023" ;
+  dcat:hasVersion <http://www.w3.org/ns/sosa/2017/oboe> ;
+  dcat:hasVersion <http://www.w3.org/ns/sosa/2023/oboe> ;
+  dcat:hasCurrentVersion <http://www.w3.org/ns/sosa/2023/oboe> ;
+  dcat:previousVersion <http://www.w3.org/ns/sosa/2017/oboe> ;
+  owl:priorVersion <http://www.w3.org/ns/sosa/2017/oboe> ;
   dcterms:created "2017-03-05"^^xsd:date ;
   dcterms:creator <http://orcid.org/0000-0002-3884-3420> ;
   dcterms:creator "Simon J D COX" ;

--- a/ssn/rdf/ontology/alignments/sosa-prov.ttl
+++ b/ssn/rdf/ontology/alignments/sosa-prov.ttl
@@ -11,6 +11,7 @@
 @prefix sosa: <http://www.w3.org/ns/sosa/> .
 @prefix sp: <http://www.w3.org/ns/sosa/prov/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 
 sosa:Execution
   rdfs:subClassOf prov:Activity ;
@@ -83,6 +84,13 @@ sosa:endTime
 .
 sosa:prov
   rdf:type owl:Ontology ;
+  owl:versionIRI <http://www.w3.org/ns/sosa/2023/prov> ;
+  dcat:version "2023" ;
+  dcat:hasVersion <http://www.w3.org/ns/sosa/2017/prov> ;
+  dcat:hasVersion <http://www.w3.org/ns/sosa/2023/prov> ;
+  dcat:hasCurrentVersion <http://www.w3.org/ns/sosa/2023/prov> ;
+  dcat:previousVersion <http://www.w3.org/ns/sosa/2017/prov> ;
+  owl:priorVersion <http://www.w3.org/ns/sosa/2017/prov> ;
   dcterms:created "2016-12-14"^^xsd:date ;
   dcterms:creator "Simon J D Cox" ;
   dcterms:creator [

--- a/ssn/rdf/ontology/alignments/sosa-saref.ttl
+++ b/ssn/rdf/ontology/alignments/sosa-saref.ttl
@@ -32,8 +32,13 @@
 @prefix sosa: <http://www.w3.org/ns/sosa/> .
 @prefix sosa-common: <http://www.w3.org/ns/sosa/common/> .
 @prefix sosa-obs: <http://www.w3.org/ns/sosa/obs/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 
 sosa:saref a owl:Ontology ;
+  owl:versionIRI <http://www.w3.org/ns/sosa/2023/saref> ;
+  dcat:version "2023" ;
+  dcat:hasVersion <http://www.w3.org/ns/sosa/2023/saref> ;
+  dcat:hasCurrentVersion <http://www.w3.org/ns/sosa/2023/saref> ;
   dcterms:created "2024-03-14"^^xsd:date ;
   dcterms:creator "Maxime Lefrançois" ;
   dcterms:creator [

--- a/ssn/rdf/ontology/core/sosa-actuation.ttl
+++ b/ssn/rdf/ontology/core/sosa-actuation.ttl
@@ -12,10 +12,15 @@
 @prefix sosa: <http://www.w3.org/ns/sosa/> .
 @prefix sosa-common: <http://www.w3.org/ns/sosa/common/> .
 @prefix sosa-act: <http://www.w3.org/ns/sosa/act/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 
 
 sosa-act: 
   a owl:Ontology ;
+  owl:versionIRI <http://www.w3.org/ns/sosa/2023/act/> ;
+  dcat:version "2023" ;
+  dcat:hasVersion <http://www.w3.org/ns/sosa/2023/act/> ;
+  dcat:hasCurrentVersion <http://www.w3.org/ns/sosa/2023/act/> ;
   dcterms:title "Sensor, Observation, Sample, and Actuator (SOSA) Ontology - actuation module"@en ;
   dcterms:description "Actuation classes and properties for the SSN Ontology."@en ;
   dcterms:creator [ a foaf:Agent ; foaf:name "W3C/OGC Spatial Data on the Web Working Group"@en ] ;

--- a/ssn/rdf/ontology/core/sosa-common.ttl
+++ b/ssn/rdf/ontology/core/sosa-common.ttl
@@ -11,10 +11,15 @@
 
 @prefix sosa: <http://www.w3.org/ns/sosa/> .
 @prefix sosa-common: <http://www.w3.org/ns/sosa/common/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 
 
 sosa-common: 
   a owl:Ontology ;
+  owl:versionIRI <http://www.w3.org/ns/sosa/2023/common/> ;
+  dcat:version "2023" ;
+  dcat:hasVersion <http://www.w3.org/ns/sosa/2023/common/> ;
+  dcat:hasCurrentVersion <http://www.w3.org/ns/sosa/2023/common/> ;
   dcterms:title "Sensor, Observation, Sample, and Actuator (SOSA) Ontology - core module"@en ;
   dcterms:description "Core classes and properties for the SSN Ontology."@en ;
   dcterms:creator [ a foaf:Agent ; foaf:name "W3C/OGC Spatial Data on the Web Working Group"@en ] ;

--- a/ssn/rdf/ontology/core/sosa-deprecated.ttl
+++ b/ssn/rdf/ontology/core/sosa-deprecated.ttl
@@ -13,9 +13,14 @@
 @prefix sosa-act: <http://www.w3.org/ns/sosa/act/> .
 @prefix sosa-obs: <http://www.w3.org/ns/sosa/obs/> .
 @prefix sosa-dep: <http://www.w3.org/ns/sosa/dep/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 
 sosa-dep: 
   a owl:Ontology ;
+  owl:versionIRI <http://www.w3.org/ns/sosa/2023/dep/> ;
+  dcat:version "2023" ;
+  dcat:hasVersion <http://www.w3.org/ns/sosa/2023/dep/> ;
+  dcat:hasCurrentVersion <http://www.w3.org/ns/sosa/2023/dep/> ;
   dcterms:title "Semantic Sensor Network Ontology - SOSA deprecated terms"@en ;
   dcterms:description """
   This module contains terms defined in the sosa: namespace in the 2017 edition that are deprecated. 

--- a/ssn/rdf/ontology/core/sosa-observation.ttl
+++ b/ssn/rdf/ontology/core/sosa-observation.ttl
@@ -12,10 +12,15 @@
 @prefix sosa: <http://www.w3.org/ns/sosa/> .
 @prefix sosa-common: <http://www.w3.org/ns/sosa/common/> .
 @prefix sosa-obs: <http://www.w3.org/ns/sosa/obs/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 
 
 sosa-obs: 
   a owl:Ontology ;
+  owl:versionIRI <http://www.w3.org/ns/sosa/2023/obs/> ;
+  dcat:version "2023" ;
+  dcat:hasVersion <http://www.w3.org/ns/sosa/2023/obs/> ;
+  dcat:hasCurrentVersion <http://www.w3.org/ns/sosa/2023/obs/> ;
   dcterms:title "Sensor, Observation, Sample, and Actuator (SOSA) Ontology - actuation module"@en ;
   dcterms:description "Observation classes and properties for the SSN Ontology."@en ;
   dcterms:creator [ a foaf:Agent ; foaf:name "W3C/OGC Spatial Data on the Web Working Group"@en ] ;

--- a/ssn/rdf/ontology/core/sosa-sampling.ttl
+++ b/ssn/rdf/ontology/core/sosa-sampling.ttl
@@ -12,10 +12,15 @@
 @prefix sosa: <http://www.w3.org/ns/sosa/> .
 @prefix sosa-common: <http://www.w3.org/ns/sosa/common/> .
 @prefix sosa-sam: <http://www.w3.org/ns/sosa/sam/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 
 
 sosa-sam: 
   a owl:Ontology ;
+  owl:versionIRI <http://www.w3.org/ns/sosa/2023/sam/> ;
+  dcat:version "2023" ;
+  dcat:hasVersion <http://www.w3.org/ns/sosa/2023/sam/> ;
+  dcat:hasCurrentVersion <http://www.w3.org/ns/sosa/2023/sam/> ;
   dcterms:title "Sensor, Observation, Sample, and Actuator (SOSA) Ontology - actuation module"@en ;
   dcterms:description "Sampling classes and properties for the SSN Ontology."@en ;
   dcterms:creator [ a foaf:Agent ; foaf:name "W3C/OGC Spatial Data on the Web Working Group"@en ] ;

--- a/ssn/rdf/ontology/core/sosa.ttl
+++ b/ssn/rdf/ontology/core/sosa.ttl
@@ -16,6 +16,7 @@
 @prefix sosa-obs: <http://www.w3.org/ns/sosa/obs/> .
 @prefix sosa-sam: <http://www.w3.org/ns/sosa/sam/> .
 @prefix sosa-dep: <http://www.w3.org/ns/sosa/dep/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 
 
 sosa: 
@@ -31,6 +32,11 @@ sosa:
   dcterms:created "2017-04-17"^^xsd:date ;
   dcterms:modified "2024-02-03"^^xsd:date ;
   owl:versionIRI <http://www.w3.org/ns/sosa/2023/> ;
+  dcat:version "2023" ;
+  dcat:hasVersion <http://www.w3.org/ns/sosa/2017/> ;
+  dcat:hasVersion <http://www.w3.org/ns/sosa/2023/> ;
+  dcat:hasCurrentVersion <http://www.w3.org/ns/sosa/2023/> ;
+  dcat:previousVersion <http://www.w3.org/ns/sosa/2017/> ;
   owl:priorVersion <http://www.w3.org/ns/sosa/2017/> ;
   owl:imports sosa-act: , sosa-obs: , sosa-sam:, sosa-dep: .
 

--- a/ssn/rdf/ontology/core/ssn-actuation.ttl
+++ b/ssn/rdf/ontology/core/ssn-actuation.ttl
@@ -12,10 +12,15 @@
 @prefix sosa-act: <http://www.w3.org/ns/sosa/act/> .
 @prefix ssn-common: <http://www.w3.org/ns/ssn/common/> .
 @prefix ssn-act: <http://www.w3.org/ns/ssn/act/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 
 
 ssn-act: 
   a owl:Ontology ;
+  owl:versionIRI <http://www.w3.org/ns/ssn/2023/act/> ;
+  dcat:version "2023" ;
+  dcat:hasVersion <http://www.w3.org/ns/ssn/2023/act/> ;
+  dcat:hasCurrentVersion <http://www.w3.org/ns/ssn/2023/act/> ;
   dcterms:title "Sensor, Observation, Sample, and Actuator (SOSA) Ontology - actuation module"@en ;
   dcterms:description "Actuation classes and properties for the SSN Ontology."@en ;
   dcterms:title "SSN Ontology - actuation module"@en ;

--- a/ssn/rdf/ontology/core/ssn-common.ttl
+++ b/ssn/rdf/ontology/core/ssn-common.ttl
@@ -10,10 +10,15 @@
 @prefix sosa: <http://www.w3.org/ns/sosa/> .
 @prefix sosa-common: <http://www.w3.org/ns/sosa/common/> .
 @prefix ssn-common: <http://www.w3.org/ns/ssn/common/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 
 
 ssn-common: 
   a owl:Ontology ;
+  owl:versionIRI <http://www.w3.org/ns/ssn/2023/common/> ;
+  dcat:version "2023" ;
+  dcat:hasVersion <http://www.w3.org/ns/ssn/2023/common/> ;
+  dcat:hasCurrentVersion <http://www.w3.org/ns/ssn/2023/common/> ;
   dcterms:title "SSN Ontology - core module"@en ;
   dcterms:description """Core classes and properties for the SSN Ontology.
   This module adds RDFS and OWL axioms to the terms defined in SOSA Core

--- a/ssn/rdf/ontology/core/ssn-deprecated.ttl
+++ b/ssn/rdf/ontology/core/ssn-deprecated.ttl
@@ -13,8 +13,13 @@
 @prefix sosa-obs: <http://www.w3.org/ns/sosa/obs/> .
 @prefix ssn: <http://www.w3.org/ns/ssn/> .
 @prefix ssn-dep: <http://www.w3.org/ns/ssn/dep/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 
 ssn-dep: a owl:Ontology ;
+  owl:versionIRI <http://www.w3.org/ns/ssn/2023/dep/> ;
+  dcat:version "2023" ;
+  dcat:hasVersion <http://www.w3.org/ns/ssn/2023/dep/> ;
+  dcat:hasCurrentVersion <http://www.w3.org/ns/ssn/2023/dep/> ;
   dcterms:title "Semantic Sensor Network Ontology - SSN deprecated terms"@en ;
   dcterms:description """
   This module contains terms defined in the ssn: namespace that now have equivalents in the sosa: namespace so are deprecated. 

--- a/ssn/rdf/ontology/core/ssn-observation.ttl
+++ b/ssn/rdf/ontology/core/ssn-observation.ttl
@@ -14,10 +14,15 @@
 @prefix sosa-obs: <http://www.w3.org/ns/sosa/obs/> .
 @prefix ssn-common: <http://www.w3.org/ns/ssn/common/> .
 @prefix ssn-obs: <http://www.w3.org/ns/ssn/obs/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 
 
 ssn-obs: 
   a owl:Ontology ;
+  owl:versionIRI <http://www.w3.org/ns/ssn/2023/obs/> ;
+  dcat:version "2023" ;
+  dcat:hasVersion <http://www.w3.org/ns/ssn/2023/obs/> ;
+  dcat:hasCurrentVersion <http://www.w3.org/ns/ssn/2023/obs/> ;
   dcterms:title "Sensor, Observation, Sample, and Actuator (SOSA) Ontology - actuation module"@en ;
   dcterms:description "Observation classes and properties for the SSN Ontology."@en ;
   dcterms:creator [ a foaf:Agent ; foaf:name "W3C/OGC Spatial Data on the Web Working Group"@en ] ;

--- a/ssn/rdf/ontology/core/ssn-sampling.ttl
+++ b/ssn/rdf/ontology/core/ssn-sampling.ttl
@@ -14,10 +14,15 @@
 @prefix sosa-sam: <http://www.w3.org/ns/sosa/sam/> .
 @prefix ssn-common: <http://www.w3.org/ns/ssn/common/> .
 @prefix ssn-sam: <http://www.w3.org/ns/ssn/sam/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 
 
 ssn-sam: 
   a owl:Ontology ;
+  owl:versionIRI <http://www.w3.org/ns/ssn/2023/sam/> ;
+  dcat:version "2023" ;
+  dcat:hasVersion <http://www.w3.org/ns/ssn/2023/sam/> ;
+  dcat:hasCurrentVersion <http://www.w3.org/ns/ssn/2023/sam/> ;
   dcterms:title "Sensor, Observation, Sample, and Actuator (SOSA) Ontology - actuation module"@en ;
   dcterms:description "Sampling classes and properties for the SSN Ontology."@en ;
   dcterms:creator [ a foaf:Agent ; foaf:name "W3C/OGC Spatial Data on the Web Working Group"@en ] ;

--- a/ssn/rdf/ontology/core/ssn.ttl
+++ b/ssn/rdf/ontology/core/ssn.ttl
@@ -18,6 +18,7 @@
 @prefix ssn-dep: <http://www.w3.org/ns/ssn/dep/> .
 @prefix ssn-obs: <http://www.w3.org/ns/ssn/obs/> .
 @prefix ssn-sam: <http://www.w3.org/ns/ssn/sam/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 
 
 ssn: a owl:Ontology ;
@@ -48,6 +49,11 @@ In particular, (a) the scope is extended to include actuation and sampling; (b) 
   dcterms:created "2017-04-17"^^xsd:date ;
   dcterms:modified "2024-02-03"^^xsd:date ;
   owl:versionIRI <http://www.w3.org/ns/ssn/2023/> ;
+  dcat:version "2023" ;
+  dcat:hasVersion <http://www.w3.org/ns/ssn/2017/> ;
+  dcat:hasVersion <http://www.w3.org/ns/ssn/2023/> ;
+  dcat:hasCurrentVersion <http://www.w3.org/ns/ssn/2023/> ;
+  dcat:previousVersion <http://www.w3.org/ns/ssn/2017/> ;
   owl:priorVersion <http://www.w3.org/ns/ssn/2017/> ;
   owl:imports ssn-act: , ssn-obs: , ssn-sam: , ssn-dep: , sosa: .
 

--- a/ssn/rdf/ontology/extensions/sample-relations.ttl
+++ b/ssn/rdf/ontology/extensions/sample-relations.ttl
@@ -12,6 +12,7 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix sosa: <http://www.w3.org/ns/sosa/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 
 sosa-rel:
   rdf:type owl:Ontology ;
@@ -23,6 +24,11 @@ sosa-rel:
   dcterms:license <http://www.opengeospatial.org/ogc/Software> ;
   dcterms:license <http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document> ;
   owl:versionIRI <http://www.w3.org/ns/sosa/2023/sampling/> ;
+  dcat:version "2023" ;
+  dcat:hasVersion <http://www.w3.org/ns/sosa/2017/sampling/> ;
+  dcat:hasVersion <http://www.w3.org/ns/sosa/2023/sampling/> ;
+  dcat:hasCurrentVersion <http://www.w3.org/ns/sosa/2023/sampling/> ;
+  dcat:previousVersion <http://www.w3.org/ns/sosa/2017/sampling/> ;
   owl:priorVersion <http://www.w3.org/ns/sosa/2017/sampling/> ;
   dcterms:rights "Copyright 2025 W3C/OGC." ;
 .

--- a/ssn/rdf/ontology/extensions/sosa-oms.ttl
+++ b/ssn/rdf/ontology/extensions/sosa-oms.ttl
@@ -19,9 +19,15 @@
 @prefix sosa-obs: <http://www.w3.org/ns/sosa/obs/> .
 @prefix sosa-sam: <http://www.w3.org/ns/sosa/sam/> .
 @prefix sosa-oms: <http://www.w3.org/ns/sosa/oms/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 
 sosa-oms: 
   a owl:Ontology ;
+  owl:versionIRI <http://www.w3.org/ns/sosa/2023/oms/> ;
+  dcat:version "2023" ;
+  dcat:hasVersion <http://www.w3.org/ns/sosa/2023/oms/> ;
+  dcat:hasCurrentVersion <http://www.w3.org/ns/sosa/2023/oms/> ;
+  dcterms:replaces <http://www.w3.org/ns/sosa/om> ;
   dcterms:title "OMS Ontology - based on (SOSA) Ontology"@en ;
   dcterms:description "This ontology is based on the SOSA Ontology by the W3C/OGC Spatial Data on the Web Working Group, supplemented by some classes and properties required to implement ISO 19156:2023 ."@en ;
   dcterms:creator [ a foaf:Agent ; foaf:name "W3C/OGC Spatial Data on the Web Working Group"@en ] ;

--- a/ssn/rdf/ontology/extensions/sosa-system.ttl
+++ b/ssn/rdf/ontology/extensions/sosa-system.ttl
@@ -13,9 +13,15 @@
 
 @prefix sosa: <http://www.w3.org/ns/sosa/> .
 @prefix sosa-systems: <http://www.w3.org/ns/sosa/systems/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 
 
 sosa-systems: a owl:Ontology , voaf:Vocabulary ;
+  owl:versionIRI <http://www.w3.org/ns/sosa/2023/systems/> ;
+  dcat:version "2023" ;
+  dcat:hasVersion <http://www.w3.org/ns/sosa/2023/systems/> ;
+  dcat:hasCurrentVersion <http://www.w3.org/ns/sosa/2023/systems/> ;
+  dcterms:replaces <http://www.w3.org/ns/ssn/systems/> ;
   dcterms:title "Ontology of operating conditions and capabilities of systems"@en ;
   dcterms:description "The System Capabilities Module imports SOSA and adds classes and properties required for the description of the operating conditions and capabilities of systems, particularly Sensors and Actuators."@en ;
   dcterms:creator [ a foaf:Agent ; foaf:name "W3C/OGC Spatio-temporal Data on the Web Working Group"@en ] ;

--- a/ssn/rdf/ontology/extensions/ssn-oms.ttl
+++ b/ssn/rdf/ontology/extensions/ssn-oms.ttl
@@ -21,9 +21,14 @@
 @prefix ssn-obs: <http://www.w3.org/ns/ssn/obs/> .
 @prefix ssn-sam: <http://www.w3.org/ns/ssn/sam/> .
 @prefix ssn-oms: <http://www.w3.org/ns/ssn/oms/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 
 
 ssn-oms: a owl:Ontology ;
+  owl:versionIRI <http://www.w3.org/ns/ssn/2023/oms/> ;
+  dcat:version "2023" ;
+  dcat:hasVersion <http://www.w3.org/ns/ssn/2023/oms/> ;
+  dcat:hasCurrentVersion <http://www.w3.org/ns/ssn/2023/oms/> ;
   dcterms:title "OMS Ontology - based on (SOSA) Ontology with SSN axiomatization"@en ;
   dcterms:description "This ontology is based on the SOSA Ontology by the W3C/OGC Spatial Data on the Web Working Group, supplemented by some classes and properties required to implement ISO 19156:2023 , with axiomatization following SSN."@en ;
   dcterms:creator [ a foaf:Agent ; foaf:name "W3C/OGC Spatial Data on the Web Working Group"@en ] ;

--- a/ssn/rdf/vocabularies/system-capabilities-properties.ttl
+++ b/ssn/rdf/vocabularies/system-capabilities-properties.ttl
@@ -14,8 +14,13 @@
 @prefix sosa: <http://www.w3.org/ns/sosa/> .
 @prefix sosa-systems: <http://www.w3.org/ns/sosa/systems/> .
 @prefix sosa-cap: <http://www.w3.org/ns/sosa/system-capability-properties#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 
 sosa-cap: a owl:Ontology , voaf:Vocabulary ;
+  owl:versionIRI <http://www.w3.org/ns/sosa/2023/system-capability-properties#> ;
+  dcat:version "2023" ;
+  dcat:hasVersion <http://www.w3.org/ns/sosa/2023/system-capability-properties#> ;
+  dcat:hasCurrentVersion <http://www.w3.org/ns/sosa/2023/system-capability-properties#> ;
   dcterms:title "Sample vocabulary of properties about system capabilities"@en ;
   dcterms:description """This vocabulary defines a short list of properties about system capabilities. 
 

--- a/ssn/rdf/vocabularies/system-environment-properties.ttl
+++ b/ssn/rdf/vocabularies/system-environment-properties.ttl
@@ -14,8 +14,13 @@
 @prefix sosa: <http://www.w3.org/ns/sosa/> .
 @prefix sosa-systems: <http://www.w3.org/ns/sosa/systems/> .
 @prefix sosa-env: <http://www.w3.org/ns/sosa/system-environment-properties#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 
 sosa-env: a owl:Ontology , voaf:Vocabulary ;
+  owl:versionIRI <http://www.w3.org/ns/sosa/2023/system-environment-properties#> ;
+  dcat:version "2023" ;
+  dcat:hasVersion <http://www.w3.org/ns/sosa/2023/system-environment-properties#> ;
+  dcat:hasCurrentVersion <http://www.w3.org/ns/sosa/2023/system-environment-properties#> ;
   dcterms:title "Sample vocabulary of properties about the system environment"@en ;
   dcterms:description """This vocabulary defines a short list of properties about the system environment. 
 


### PR DESCRIPTION
Two editions of SOSA/SSN are about to be served side by side under `https://www.w3.org/ns/`, and nothing in the graphs says how they relate.

## Why DCAT

OWL says that an ontology supersedes an older one — `owl:priorVersion`, `owl:backwardCompatibleWith` — but it has no way for an edition to point **forward** to a newer one. That is the direction a reader needs: someone who dereferences a 2017 IRI should learn that a 2023 edition exists.

DCAT has that vocabulary, and [w3c/ns](https://github.com/w3c/ns) already uses it for exactly this problem: `dcat.ttl` is published there as `dcat2.ttl` and `dcat3.ttl`, both declaring the same ontology IRI, telling the editions apart with `dcat:version`, `dcat:hasVersion` and `dcat:hasCurrentVersion`. Same repository, same server, same question, and a W3C Recommendation for the job.

## What this changes

Each module now carries:

```turtle
sosa: a owl:Ontology ;
  owl:versionIRI <http://www.w3.org/ns/sosa/2023/> ;
  dcat:version "2023" ;
  dcat:hasVersion <http://www.w3.org/ns/sosa/2017/> , <http://www.w3.org/ns/sosa/2023/> ;
  dcat:hasCurrentVersion <http://www.w3.org/ns/sosa/2023/> ;
  dcat:previousVersion <http://www.w3.org/ns/sosa/2017/> ;
  owl:priorVersion <http://www.w3.org/ns/sosa/2017/> .
```

A module with no 2017 counterpart gets the same minus the two backward pointers. A module that took over from one published under **another** IRI in 2017 says so with `dcterms:replaces`:

| module | replaces |
|---|---|
| `sosa/systems/` | `ssn/systems/` |
| `sosa/dul` | `ssn/dul` |
| `sosa/oms/` | `sosa/om` |

**`owl:versionIRI` on every module.** Only `sosa.ttl`, `ssn.ttl` and `sample-relations.ttl` declared one before. A version IRI cannot be published for a module that does not claim it, so all 25 modules under `/ns/` now do.

`sosa-sdo.ttl` is left alone: it declares `https://example.org/sosa-sdo-mapping`, so it has no home under `/ns/` and no version IRI to claim.

## The other half, in w3c/ns

The 2017 files carry the mirror image of these statements, added in the namespace repository: `dcat:hasCurrentVersion` pointing at 2023, and, for the four modules the 2023 edition no longer serves under their IRI — `ssn:ext`, `sosa:om`, `ssn:dul`, `ssn:systems/` — `owl:deprecated true` with `dcterms:isReplacedBy` naming the successor where there is one. That is a change of meaning to files published with a Recommendation, and it is for the working group to confirm.

## For the working group

1. **Deprecating the four withdrawn 2017 modules** — the point above. Confirm or object.
2. **`owl:backwardCompatibleWith`** is deliberately absent. The transition says the 2023 edition "adds features while remaining compatible", but that has to be judged module by module, not in bulk, and the working group is better placed to say it than a script.
3. `check_repository.py` passes on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)