### PR TITLE
Bring the SAREF alignment back in step with SOSA and with SAREF V4.1.1

### DIFF
--- a/ssn/rdf/ontology/alignments/sosa-saref.ttl
+++ b/ssn/rdf/ontology/alignments/sosa-saref.ttl
@@ -267,10 +267,12 @@ sosa:startTime owl:equivalentProperty saref:hasStartTime .
 #
 # - `sosa:hasDeployment` and its inverse `sosa:deployedAsset`
 # - `sosa:isHostedBy` and its inverse `sosa:hosts`
-# 
+#
+# `sosa:Asset` is the resource involved in a Deployment, and `sosa:Platform` and `sosa:System` are both subclasses of it. It is the one place to say that these are systems in the SAREF4SYST sense, and features of interest in the SAREF sense — `saref:FeatureOfInterest` being more general than `sosa:FeatureOfInterest`, an entity can be one without being the target of any execution.
 
 sosa:Asset
-  rdfs:subClassOf s4syst:System . 
+  rdfs:subClassOf s4syst:System ;
+  rdfs:subClassOf saref:FeatureOfInterest . 
 
 
 ### Deployment
@@ -288,10 +290,7 @@ sosa:Asset
 #
 # - `sosa:hosts` and its inverse `sosa:isHostedBy`
 # 
-# `saref:FeatureOfInterest` being more general than `sosa:FeatureOfInterest`, this alignemnt maps `sosa:Platform` to `saref:FeatureOfInterest` and `s4syst:System`. 
-
-sosa:Platform
-  rdfs:subClassOf s4syst:System . 
+# `sosa:Platform` is a subclass of `sosa:Asset`, so it is already a `s4syst:System` and a `saref:FeatureOfInterest`. 
 
 
 ### Systems
@@ -299,16 +298,12 @@ sosa:Platform
 # In SOSA/SSN, `sosa:System` is a generalization of `sosa:Sensor`, `sosa:Actuator` and `sosa:Sampler`, where `sosa:Sensor` covers devices, agents (including humans), or softwares (simulations). 
 # In SAREF, a `saref:Device` is "a tangible object designed to accomplish a particular task. To accomplish this task, the device performs one or more functions. An instance of saref:Device represents one specific real world entity.".
 # `sosa:System` is positionned in the middle of the hierarchy:
-# `saref:Device` < `sosa:System`  < `s4syst:System`
-#                                 < `saref:FeatureOfInterest` 
+# `saref:Device` < `sosa:System` < `sosa:Asset` < `s4syst:System`
+#                                              < `saref:FeatureOfInterest` 
 
 saref:Device
   rdfs:subClassOf sosa:System .
 
-sosa:System
-  rdfs:subClassOf s4syst:System ;
-  rdfs:subClassOf saref:FeatureOfInterest .
-  
 
 # SAREF adds the concept of `saref:DeviceKind`, which allows to describe kinds of devices, with common properties and common states having the same value, and with common functions and services. Devices kinds may be used to describe models of devices in online catalogues.
 # There is no equivalent in SOSA/SSN to `saref:DeviceKind`.

--- a/ssn/rdf/ontology/alignments/sosa-saref.ttl
+++ b/ssn/rdf/ontology/alignments/sosa-saref.ttl
@@ -44,12 +44,24 @@ sosa:saref a owl:Ontology ;
   dcterms:license <http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document> ;
   dcterms:modified "2024-03-14"^^xsd:date ;
   dcterms:modified "2025-02-19"^^xsd:date ;
+  dcterms:modified "2026-09-12"^^xsd:date ;
   dcterms:rights "Copyright 2025 W3C/OGC." ;
   rdfs:comment """Alignment of the the W3C/OGC SOSA Ontology with the ETSI Smart Applications REFerence Ontology (SAREF)."""@en ;
   rdfs:label "Alignment of SOSA with SAREF Core V4.1.1"@en ;
   owl:imports <https://saref.etsi.org/core/v4.1.1> ;
   owl:imports <https://saref.etsi.org/saref4syst/v1.1.2> ;
   owl:imports sosa: .
+
+# Note on SAREF V4.1.1. The ontology this file imports and ETSI TS 103 264 V4.1.1
+# do not agree on three terms, and this alignment follows the ontology, which is
+# what a reasoner that imports it actually sees:
+#
+# - the TS names `saref:actsUpon` where the ontology has `saref:targets`;
+# - the TS names `saref:isActedUponBy` where the ontology has `saref:isTargetOf`;
+# - the TS specifies `saref:hasStartTime` (clause 5.11.1) and the ontology does
+#   not declare it, so this file declares it. See the startTime section below.
+#
+# All three are known, and are to be settled in SAREF V4.1.2.
 
 ## Alignment sosa-common and SAREF Core and SAREF4SYST
 
@@ -95,7 +107,7 @@ saref:StateOfInterest
 
 ### hasFeatureOfInterest, forProperty, observes, observedProperty, actsOn, actsOnProperty
 
-# In SAREF, a device can act upon (OP `saref:actsUpon`) features, properties, or states. SAREF Core defines `saref:observes` and `saref:controls` as subproperties of `saref:actsUpon`. Property `saref:actsUpon` also applies to functions, commands, and procedure executions.
+# In SAREF, a device can act upon (OP `saref:targets`) features, properties, or states. SAREF Core defines `saref:observes` and `saref:controls` as subproperties of `saref:targets`. Property `saref:targets` also applies to functions, commands, and procedure executions.
 # In SOSA/SSN, different object properties are used depending on the context. It would be:
 #
 # - `sosa:hasFeatureOfInterest` from execution to feature of interest
@@ -105,24 +117,24 @@ saref:StateOfInterest
 # Thus, all these properties are subproperties of the SAREF properties.
 
 sosa:hasFeatureOfInterest
-  rdfs:subPropertyOf saref:actsUpon . # this also covers sosa:isFeatureOfInterestOf
+  rdfs:subPropertyOf saref:targets . # this also covers sosa:isFeatureOfInterestOf
 
 sosa:hasUltimateFeatureOfInterest
-  rdfs:subPropertyOf saref:actsUpon . # this also covers sosa:isUltimateFeatureOfInterestOf
+  rdfs:subPropertyOf saref:targets . # this also covers sosa:isUltimateFeatureOfInterestOf
 
 sosa:forProperty
-  rdfs:subPropertyOf saref:actsUpon .
+  rdfs:subPropertyOf saref:targets .
 
 
-# `sosa:hasProcedure` links a Property and a Procedure that can observe or act on it. This corresponds to a restrictive application of `saref:isActedUponBy` in SAREF, which is defined as "Links a feature, property, or state, to the device, function, command, or procedure execution, that acts on it.". 
+# `sosa:hasProcedure` links a Property and a Procedure that can observe or act on it. This corresponds to a restrictive application of `saref:isTargetOf` in SAREF, which is defined as "Links a feature, property, or state, to the device, function, command, or procedure execution, that targets it.". 
 
 sosa:hasProcedure 
-  rdfs:subPropertyOf saref:isActedUponBy .
+  rdfs:subPropertyOf saref:isTargetOf .
 
-# `sosa:propertyFor` is defined as "A relation between a Property and some entity.". Three examples are given: from a Sensor to the properties it can observe; from an Actuator to the properties it can act on; from a SystemCapability to the Property the capability is described for. In the two first examples, SAREF would offer as equivalent `saref:isActedUponBy`, which is defined as "Links a feature, property, or state, to the device, function, command, or procedure execution, that acts on it.". In the third example, it is less clear what would be the equivalent in SAREF.
+# `sosa:propertyFor` is defined as "A relation between a Property and some entity.". Three examples are given: from a Sensor to the properties it can observe; from an Actuator to the properties it can act on; from a SystemCapability to the Property the capability is described for. In the two first examples, SAREF would offer as equivalent `saref:isTargetOf`, which is defined as "Links a feature, property, or state, to the device, function, command, or procedure execution, that targets it.". In the third example, it is less clear what would be the equivalent in SAREF.
 
 sosa:propertyFor
-  rdfs:subPropertyOf saref:isActedUponBy . 
+  rdfs:subPropertyOf saref:isTargetOf . 
 
 
 ### link entity to property of that entity
@@ -241,6 +253,10 @@ sosa:resultTime owl:equivalentProperty saref:hasResultTime .
 
 
 # SAREF `saref:hasStartTime` is equivalent to SOSA/SSN `sosa:startTime`, SAREF added prefix `has` to conform to naming best practices.
+# ETSI TS 103 264 V4.1.1 clause 5.11.1 specifies it — "DP saref:hasStartTime links a procedure execution to the instant of time when it was initiated or tasked, expressed as an xsd:dateTime literal" — but the V4.1.1 ontology does not declare it, and is to do so in V4.1.2.
+# Until then the declaration is made here: without it an OWL parser cannot tell whether the equivalence holds between object or between data properties, and drops the axiom.
+
+saref:hasStartTime a owl:DatatypeProperty .
 
 sosa:startTime owl:equivalentProperty saref:hasStartTime .
 
@@ -333,7 +349,7 @@ saref:Sensor
 # - `sosa:originated` and its inverse `sosa:wasOriginatedBy`
 
 
-# In SAREF, a device can act upon (OP `saref:actsUpon`) features, properties, or states. SAREF Core defines `saref:observes` and `saref:controls` as subproperties of `saref:actsUpon`. Property `saref:actsUpon` also applies to functions, commands, and procedure executions.
+# In SAREF, a device can act upon (OP `saref:targets`) features, properties, or states. SAREF Core defines `saref:observes` and `saref:controls` as subproperties of `saref:targets`. Property `saref:targets` also applies to functions, commands, and procedure executions.
 # In SOSA/SSN, different object properties are used depending on the context. It would be:
 #
 # - `sosa:observes` from sensor to property
@@ -381,7 +397,7 @@ sosa:Actuation
 saref:Actuator
   rdfs:subClassOf sosa:Actuator .
 
-# In SAREF, a device can act upon (OP `saref:actsUpon`) features, properties, or states. SAREF Core defines `saref:observes` and `saref:controls` as subproperties of `saref:actsUpon`. Property `saref:actsUpon` also applies to functions, commands, and procedure executions.
+# In SAREF, a device can act upon (OP `saref:targets`) features, properties, or states. SAREF Core defines `saref:observes` and `saref:controls` as subproperties of `saref:targets`. Property `saref:targets` also applies to functions, commands, and procedure executions.
 # In SOSA/SSN, different object properties are used depending on the context. It would be:
 #
 # - `sosa:actsOn` from actuator to property

--- a/ssn/rdf/ontology/alignments/sosa-saref.ttl
+++ b/ssn/rdf/ontology/alignments/sosa-saref.ttl
@@ -69,9 +69,9 @@ sosa:saref a owl:Ontology ;
 
 ### FeatureOfInterest
 
-# In SOSA/SSN, `sosa:FeatureOfInterest` is the class of things that are the target of an execution or a deployment. 
+# In SOSA/SSN, `sosa:FeatureOfInterest` is the "entity that is the target of an Execution or ExecutionCollection or Deployment". 
 # In SAREF, `saref:FeatureOfInterest` is the class of real world entities from which a property or a state may be acted upon, such as observed and controlled.
-# So `saref:FeatureOfInterest` is more general than `sosa:FeatureOfInterest`. An entity can be a `saref:FeatureOfInterest` even if it is not the target of an execution or a deployment.
+# So `saref:FeatureOfInterest` is more general than `sosa:FeatureOfInterest`. An entity can be a `saref:FeatureOfInterest` even if it is the target of no execution and no deployment.
 
 sosa:FeatureOfInterest
   rdfs:subClassOf saref:FeatureOfInterest .
@@ -86,7 +86,7 @@ sosa:FeatureOfInterest
 
 ### Property
 
-# In SOSA/SSN, a `sosa:Property` can apply to different features of interest. Section 8.8.3 "Feature-specific properties" states that a property may be made specific to a single feature of interest using sosa:isPropertyOf.
+# In SOSA/SSN, a `sosa:Property` is an "identifiable quality of features of interest that can be observed or acted upon", and can apply to different features of interest. The section "Feature-specific properties" states that a property may be made specific to a single feature of interest using sosa:isPropertyOf.
 # In SAREF, an instance of `saref:Property` can apply to different features of interest, while an instance of `saref:PropertyOfInterest` is specific to a feature of interest. It is inherent to and cannot exist without that feature of interest.
 # SAREF also defines states, that refer to the identifiable conditions that features of interest are or may be in, and that can be acted upon by devices, such as observed and controlled. States and Properties are parallel, distinct, but not disjoint. Users can chose whichever seems to best fit their needs. 
 # While states can apply to different features of interest, states of interest are specific to a feature of interest.
@@ -126,12 +126,12 @@ sosa:forProperty
   rdfs:subPropertyOf saref:targets .
 
 
-# `sosa:hasProcedure` links a Property and a Procedure that can observe or act on it. This corresponds to a restrictive application of `saref:isTargetOf` in SAREF, which is defined as "Links a feature, property, or state, to the device, function, command, or procedure execution, that targets it.". 
+# `sosa:hasProcedure` is the "relation from a Property to a Procedure that can act on or observe that Property". This corresponds to a restrictive application of `saref:isTargetOf` in SAREF, which is defined as "Links a feature, property, or state, to the device, function, command, or procedure execution, that targets it.". 
 
 sosa:hasProcedure 
   rdfs:subPropertyOf saref:isTargetOf .
 
-# `sosa:propertyFor` is defined as "A relation between a Property and some entity.". Three examples are given: from a Sensor to the properties it can observe; from an Actuator to the properties it can act on; from a SystemCapability to the Property the capability is described for. In the two first examples, SAREF would offer as equivalent `saref:isTargetOf`, which is defined as "Links a feature, property, or state, to the device, function, command, or procedure execution, that targets it.". In the third example, it is less clear what would be the equivalent in SAREF.
+# `sosa:propertyFor` is defined as the "relation from a Property to some Procedure or System that acts on it or observes that Property", and `sosa:hasProcedure` is one of its sub-properties. Its examples run from a Sensor to the properties it can observe, and from an Actuator to the properties it can act on; for both, SAREF offers `saref:isTargetOf`, "Links a feature, property, or state, to the device, function, command, or procedure execution, that targets it.".
 
 sosa:propertyFor
   rdfs:subPropertyOf saref:isTargetOf . 
@@ -295,7 +295,7 @@ sosa:Asset
 
 ### Systems
 
-# In SOSA/SSN, `sosa:System` is a generalization of `sosa:Sensor`, `sosa:Actuator` and `sosa:Sampler`, where `sosa:Sensor` covers devices, agents (including humans), or softwares (simulations). 
+# In SOSA/SSN, `sosa:System` is "an Asset that implements a Procedure in the context of an Execution", and generalizes `sosa:Sensor`, `sosa:Actuator` and `sosa:Sampler`. Each of those may be a device, a piece of infrastructure, an agent (including humans), or a software-based system.
 # In SAREF, a `saref:Device` is "a tangible object designed to accomplish a particular task. To accomplish this task, the device performs one or more functions. An instance of saref:Device represents one specific real world entity.".
 # `sosa:System` is positionned in the middle of the hierarchy:
 # `saref:Device` < `sosa:System` < `sosa:Asset` < `s4syst:System`
@@ -331,7 +331,7 @@ sosa:Observation
 ### Sensor
 
 # SAREF `saref:Sensor` is a subclass of `saref:Device`, which must be a tangible object.
-# SOSA/SSN `sosa:Sensor` covers devices, agents (including humans), or softwares (simulations). 
+# SOSA/SSN `sosa:Sensor` is a "System that implements an ObservingProcedure to determine the value of an observable Property", and "may be a device, a piece of infrastructure, an agent (including humans), or a software-based system, including systems performing simulations". 
 # So `saref:Sensor` is more specific than `sosa:Sensor`.
 
 saref:Sensor
@@ -358,8 +358,7 @@ sosa:observes
 sosa:observedProperty # also covers sosa:wasObservedBy
   rdfs:subPropertyOf saref:observes .
 
-# In SOSA/SSN, `sosa:madeBySensor` is only defined to be a subproperty of `sosa:madeBySystem` in SSN, not in SOSA. 
-# This file explicits the alignment between `sosa:madeBySensor` and `saref:madeBy` in case it is used only with SOSA (without SSN).
+# `sosa:madeBySensor` is a subproperty of `sosa:madeBySystem` in `sosa-observation.ttl` itself, so the alignment below is entailed by the one on `sosa:madeBySystem`. It is kept because this file is read as well as reasoned over.
 
 sosa:madeBySensor  # this also covers sosa:madeObservation
   rdfs:subPropertyOf saref:madeBy .
@@ -386,8 +385,8 @@ sosa:Actuation
 ### Actuator
 
 # SAREF `saref:Actuator` is a subclass of `saref:Device`, which must be a tangible object.
-# SOSA/SSN `sosa:Actuator` covers devices. Issue [#280](https://github.com/w3c/sdw-sosa-ssn/issues/280) discusses whether it should be relaxed to other entities such as humans.
-# In this file, `saref:Actuator` is assumed to be more specific than `sosa:Actuator`.
+# SOSA/SSN `sosa:Actuator` is a "System that implements an ActuatingProcedure to change the value of an actuatable Property", and since [#280](https://github.com/w3c/sdw-sosa-ssn/issues/280) was settled it "may be a device, a piece of infrastructure, an agent (including humans), or a software-based system".
+# So `saref:Actuator` is more specific than `sosa:Actuator`.
 
 saref:Actuator
   rdfs:subClassOf sosa:Actuator .
@@ -406,8 +405,7 @@ sosa:actsOn
 sosa:actsOnProperty # also covers sosa:wasActedOnBy
   rdfs:subPropertyOf saref:controls .
 
-# In SOSA/SSN, `sosa:madeByActuator` is only defined to be a subproperty of `sosa:madeBySystem` in SSN, not in SOSA. 
-# This file explicits the alignment between `sosa:madeByActuator` and `saref:madeBy` in case it is used only with SOSA (without SSN).
+# `sosa:madeByActuator` is a subproperty of `sosa:madeBySystem` in `sosa-actuation.ttl` itself, so the alignment below is entailed by the one on `sosa:madeBySystem`. It is kept because this file is read as well as reasoned over.
 
 sosa:madeByActuator  # this also covers sosa:madeActuation
   rdfs:subPropertyOf saref:madeBy .
@@ -443,15 +441,13 @@ sosa:hasOriginalSample
   rdfs:subPropertyOf s4syst:hasSubSystem .
 
 
-# In SOSA/SSN, `sosa:Sampling` is only defined to be a subclass of `sosa:Procedure` in SSN, not in SOSA. 
-# This file explicits the alignment between `sosa:Sampling` and `saref:ProcedureExecution` in case it is used only with SOSA (without SSN).
+# `sosa:Sampling` is a subclass of `sosa:Execution` in `sosa-sampling.ttl` itself, so the alignment below is entailed by `sosa:Execution owl:equivalentClass saref:ProcedureExecution`. It is kept because this file is read as well as reasoned over.
 
 sosa:Sampling
   rdfs:subClassOf saref:ProcedureExecution .
 
 
-# In SOSA/SSN, `sosa:madeBySampler` is only defined to be a subproperty of `sosa:madeBySystem` in SSN, not in SOSA. 
-# This file explicits the alignment between `sosa:madeBySampler` and `saref:madeBy` in case it is used only with SOSA (without SSN).
+# `sosa:madeBySampler` is a subproperty of `sosa:madeBySystem` in `sosa-sampling.ttl` itself, so the alignment below is entailed by the one on `sosa:madeBySystem`. It is kept because this file is read as well as reasoned over.
 
 sosa:madeBySampler
   rdfs:subPropertyOf saref:madeBy . # this also covers sosa:madeSampling


### PR DESCRIPTION
The SAREF alignment was last revised in May 2025. Since then SOSA grew a `sosa:Asset` class above `Platform` and `System`, moved a batch of sub-class and sub-property axioms out of SSN into the `sosa-*` modules, and reworded a number of definitions — while SAREF published a V4.1.1 ontology that does not quite match its own Technical Specification. This brings the file back in step with both.

Nothing about the *intent* of the alignment changes. What changes is which terms it names, where it says things, and what its comments claim.

## 1. Follow the SAREF ontology where it and TS 103 264 disagree

The file imports `<https://saref.etsi.org/core/v4.1.1>`, and that ontology and **ETSI TS 103 264 V4.1.1** disagree on three terms:

| | TS 103 264 V4.1.1 | ontology at `core/v4.1.1/saref.ttl` |
|---|---|---|
| clause 5.2, 5.11.1 | `saref:actsUpon` | **`saref:targets`** |
| clause 5.11.1 | `saref:isActedUponBy` | **`saref:isTargetOf`** |
| clause 5.11.1 | `saref:hasStartTime` (DP) | **not declared** |

The renames are recorded only in `skos:historyNote` on the individual terms — neither the TS change list nor the ontology's own `rdfs:comment` change list mentions them.

A reasoner sees the ontology, not the TS, so the alignment now follows the ontology. Five axioms were naming properties that do not exist. The `sosa:startTime` equivalence was worse than dead: with no declaration for `saref:hasStartTime`, an OWL parser cannot decide whether the equivalence holds between object or between data properties, and **drops the axiom entirely** — verified against the OWL API. The alignment is kept and the declaration made here, until V4.1.2 settles all three. A note at the top of the file records why.

The rename also makes the file do what its comments always said. `saref:isTargetOf` is declared `owl:inverseOf saref:targets`, where the old undeclared names carried no inverse — so `sosa:isFeatureOfInterestOf` and `sosa:isUltimateFeatureOfInterestOf` are now genuinely covered, exactly as the `# this also covers …` comments promise.

## 2. Say once, on `sosa:Asset`, what Platform and System inherit

`sosa:Asset` arrived in `sosa-common` in January, above `sosa:Platform` and `sosa:System`, and the alignment gained a line for it without the two older lines being revisited. Both had become entailed:

```diff
 sosa:Asset
-  rdfs:subClassOf s4syst:System .
-
-sosa:Platform
-  rdfs:subClassOf s4syst:System .
-
-sosa:System
-  rdfs:subClassOf s4syst:System ;
-  rdfs:subClassOf saref:FeatureOfInterest .
+  rdfs:subClassOf s4syst:System ;
+  rdfs:subClassOf saref:FeatureOfInterest .
```

The comment on `Platform` claimed this alignment maps it to `saref:FeatureOfInterest` *and* `s4syst:System`, and no axiom ever did the first half — HermiT confirms `sosa:Platform` was not a `saref:FeatureOfInterest`. Carrying it on `Asset` makes the comment true and covers `System` by the same stroke.

## 3. Refresh the SOSA/SSN definitions the comments quote

The comments carry the reasoning behind each axiom, and they quote definitions that have moved. Four had gone from stale to wrong:

- three say `sosa:madeBySensor`, `madeByActuator` and `madeBySampler` are sub-properties of `sosa:madeBySystem` **"in SSN, not in SOSA"**, and a fourth says the same of `sosa:Sampling` under `sosa:Procedure`. Those axioms moved into the `sosa-*` modules in October 2025, and `sosa:Sampling` is under `sosa:Execution`, not `sosa:Procedure`;
- `sosa:propertyFor` no longer reads "A relation between a Property and some entity", and its third example named a `SystemCapability` — a class that no longer exists anywhere in the ontology;
- `sosa:Actuator` "covers devices", with a note that [#280](https://github.com/w3c/sdw-sosa-ssn/issues/280) was discussing whether to relax it. #280 was settled, and in the direction it asked: an Actuator may be a device, a piece of infrastructure, an agent, or a software-based system. That is what made `saref:Actuator` the more specific of the two all along.

`FeatureOfInterest`, `Property`, `hasProcedure`, `Sensor` and `System` are refreshed too, and the hard clause number for "Feature-specific properties" is replaced by its title, section numbers being generated.

## What was deliberately left alone

An entailment check — each alignment axiom removed in turn, then asked of HermiT — finds **twelve** axioms the imports already entail, not the two this PR removes. The other ten are kept:

- the four above, whose comments now say they are entailed. They were put there on purpose, "in case it is used only with SOSA (without SSN)"; that reason has expired, but an alignment file is read as much as it is reasoned over;
- `sosa:MaterialSample`, `SpatialSample`, `StatisticalSample` under `saref:FeatureOfInterest`, entailed through `sosa:Sample`;
- `sosa:hasProcedure ⊑ saref:isTargetOf`, entailed through `sosa:propertyFor`;
- `sosa:madeBySystem ≡ saref:madeBy` and `sosa:madeExecution ≡ saref:madeExecution`, which entail **each other** through the two `owl:inverseOf` declarations — dropping either is safe, dropping both loses the alignment.

Say the word and they go in a follow-up.

Three OWL 2 DL profile violations also remain in this file — `dcterms:rights`, `foaf:name` and `foaf:Agent` undeclared. They are the same family as #528 §1 and §2, which #529 fixes for the core, extension and vocabulary modules; the alignments were out of scope there.

## Verification

Loaded with SAREF Core V4.1.1 and SAREF4SYST V1.1.2 on disk (V1.1.2 is the latest ETSI publishes), through the OWL API and HermiT:

| | before | after |
|---|---|---|
| OWL 2 DL violations held by this file | 5 | 0 (bar the three above) |
| consistent | yes | yes |
| unsatisfiable classes | 0 | 0 |
| same, with all of SSN loaded alongside | 0 unsat | 0 unsat |

Every SOSA/SSN ↔ SAREF subsumption the alignment entails was enumerated before and after. **Four are gained** — `sosa:Asset` and `sosa:Platform` under `saref:FeatureOfInterest`, `sosa:isFeatureOfInterestOf` and `sosa:isUltimateFeatureOfInterestOf` under `saref:isTargetOf`. **Four disappear**, all of them bridges to `saref:actsUpon` and `saref:isActedUponBy`, which exist only because this file used to conjure them; the real SAREF hierarchy was always reached through `saref:observes` and `saref:controls`. Everything else is identical, term for term.

`check_repository.ldpy` reports no change in any other section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
